### PR TITLE
feat: V3采购规则-金额分级审批与风险供应商拦截 (#5)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 
 config :unibo_ex_poc,
   ecto_repos: [UniboExPoc.Repo],
-  ash_domains: [UniboExPoc.Purchasing, UniboExPoc.PurchasingV2],
+  ash_domains: [UniboExPoc.Purchasing, UniboExPoc.PurchasingV2, UniboExPoc.PurchasingV3],
   generators: [timestamp_type: :utc_datetime]
 
 config :unibo_ex_poc, UniboExPocWeb.Graphql.RuntimeConfig,

--- a/lib/unibo_ex_poc/purchasing_v3.ex
+++ b/lib/unibo_ex_poc/purchasing_v3.ex
@@ -1,0 +1,17 @@
+defmodule UniboExPoc.PurchasingV3 do
+  @moduledoc """
+  V3 采购领域：验证金额分级审批 + 风险供应商拦截。
+  """
+  use Ash.Domain,
+    extensions: [AshGraphql.Domain]
+
+  graphql do
+    # V3 沿用应用层授权控制
+    authorize?(true)
+  end
+
+  resources do
+    resource(UniboExPoc.PurchasingV3.Party)
+    resource(UniboExPoc.PurchasingV3.Order)
+  end
+end

--- a/lib/unibo_ex_poc/purchasing_v3/actor.ex
+++ b/lib/unibo_ex_poc/purchasing_v3/actor.ex
@@ -1,0 +1,8 @@
+defmodule UniboExPoc.PurchasingV3.Actor do
+  @moduledoc """
+  V3 Actor：用于规则验证时传递操作者身份。
+  """
+
+  @enforce_keys [:id, :role]
+  defstruct [:id, :role]
+end

--- a/lib/unibo_ex_poc/purchasing_v3/order.ex
+++ b/lib/unibo_ex_poc/purchasing_v3/order.ex
@@ -1,0 +1,235 @@
+defmodule UniboExPoc.PurchasingV3.Order do
+  @moduledoc """
+  V3 采购订单：金额分级审批 + 风险供应商拦截。
+  """
+  use Ash.Resource,
+    otp_app: :unibo_ex_poc,
+    domain: UniboExPoc.PurchasingV3,
+    data_layer: AshPostgres.DataLayer,
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
+
+  @approval_threshold Decimal.new("100000")
+
+  graphql do
+    type(:order_v3)
+
+    queries do
+      get(:get_order_v3, :read)
+      list(:list_orders_v3, :read)
+    end
+
+    mutations do
+      create(:create_order_v3, :create)
+      update(:submit_order_v3, :submit)
+      update(:approve_order_v3, :approve)
+      update(:senior_approve_order_v3, :senior_approve)
+      update(:reject_order_v3, :reject)
+    end
+  end
+
+  postgres do
+    table("v3_orders")
+    repo(UniboExPoc.Repo)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute :order_name, :string do
+      allow_nil?(false)
+      public?(true)
+    end
+
+    attribute :status, :atom do
+      constraints(one_of: [:created, :submitted, :approved, :rejected])
+      default(:created)
+      allow_nil?(false)
+      public?(true)
+    end
+
+    attribute :total_amount, :decimal do
+      allow_nil?(false)
+      default(Decimal.new(0))
+      public?(true)
+    end
+
+    attribute :created_by_id, :uuid do
+      allow_nil?(false)
+      public?(true)
+    end
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  relationships do
+    belongs_to :supplier, UniboExPoc.PurchasingV3.Party do
+      allow_nil?(false)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:order_name, :total_amount])
+      argument(:supplier_id, :uuid, allow_nil?: false)
+
+      change(manage_relationship(:supplier_id, :supplier, type: :append, on_lookup: :relate))
+
+      # 规则：写入创建人
+      change(
+        before_action(fn changeset, context ->
+          with %{id: actor_id} <- Map.get(context, :actor),
+               true <- is_binary(actor_id) and actor_id != "" do
+            Ash.Changeset.force_change_attribute(changeset, :created_by_id, actor_id)
+          else
+            _ -> Ash.Changeset.add_error(changeset, field: :created_by_id, message: "actor.id 缺失")
+          end
+        end)
+      )
+
+      # 规则：供应商必须可合作且非高风险
+      change(
+        before_action(fn changeset, _context ->
+          supplier_id = Ash.Changeset.get_argument(changeset, :supplier_id)
+
+          case Ash.get(UniboExPoc.PurchasingV3.Party, supplier_id, authorize?: false) do
+            {:ok, supplier} ->
+              cond do
+                supplier.status != :active ->
+                  Ash.Changeset.add_error(changeset,
+                    field: :supplier_id,
+                    message: "供应商状态不是可合作状态，禁止下单"
+                  )
+
+                supplier.is_blocked ->
+                  Ash.Changeset.add_error(changeset,
+                    field: :supplier_id,
+                    message: "供应商已被禁用，禁止下单"
+                  )
+
+                supplier.risk_level == :high ->
+                  Ash.Changeset.add_error(changeset,
+                    field: :supplier_id,
+                    message: "供应商风险等级过高，禁止下单"
+                  )
+
+                true ->
+                  changeset
+              end
+
+            {:error, _error} ->
+              Ash.Changeset.add_error(changeset, field: :supplier_id, message: "供应商不存在")
+          end
+        end)
+      )
+    end
+
+    update :submit do
+      accept([])
+
+      validate attribute_equals(:status, :created) do
+        message("只有已创建订单可以提交")
+      end
+
+      change(set_attribute(:status, :submitted))
+    end
+
+    update :approve do
+      require_atomic?(false)
+      accept([])
+
+      validate attribute_equals(:status, :submitted) do
+        message("只有已提交订单可以审批")
+      end
+
+      # 规则：大额订单不能走普通审批
+      change(
+        before_action(fn changeset, _context ->
+          total_amount = Ash.Changeset.get_data(changeset, :total_amount) || Decimal.new(0)
+
+          if Decimal.compare(total_amount, @approval_threshold) == :lt do
+            changeset
+          else
+            Ash.Changeset.add_error(changeset,
+              field: :total_amount,
+              message: "订单金额达到分级阈值，需走高级审批"
+            )
+          end
+        end)
+      )
+
+      change(set_attribute(:status, :approved))
+    end
+
+    update :senior_approve do
+      require_atomic?(false)
+      accept([])
+
+      validate attribute_equals(:status, :submitted) do
+        message("只有已提交订单可以执行高级审批")
+      end
+
+      # 规则：高级审批只允许处理大额订单
+      change(
+        before_action(fn changeset, _context ->
+          total_amount = Ash.Changeset.get_data(changeset, :total_amount) || Decimal.new(0)
+
+          if Decimal.compare(total_amount, @approval_threshold) in [:eq, :gt] do
+            changeset
+          else
+            Ash.Changeset.add_error(changeset,
+              field: :total_amount,
+              message: "小额订单无需高级审批"
+            )
+          end
+        end)
+      )
+
+      # 规则：高级审批必须由主管角色执行
+      change(
+        before_action(fn changeset, context ->
+          case Map.get(context, :actor) do
+            %{role: :admin} ->
+              changeset
+
+            _ ->
+              Ash.Changeset.add_error(changeset,
+                field: :status,
+                message: "仅采购主管可执行高级审批"
+              )
+          end
+        end)
+      )
+
+      change(set_attribute(:status, :approved))
+    end
+
+    update :reject do
+      accept([])
+
+      validate attribute_in(:status, [:submitted, :approved]) do
+        message("只有已提交/已审批订单可以驳回")
+      end
+
+      change(set_attribute(:status, :rejected))
+    end
+  end
+
+  policies do
+    policy action_type(:create) do
+      authorize_if(expr(^actor(:role) in [:buyer, :admin]))
+    end
+
+    policy action_type(:read) do
+      authorize_if(always())
+    end
+
+    policy action_type(:update) do
+      authorize_if(expr(^actor(:role) == :admin or created_by_id == ^actor(:id)))
+    end
+  end
+end

--- a/lib/unibo_ex_poc/purchasing_v3/party.ex
+++ b/lib/unibo_ex_poc/purchasing_v3/party.ex
@@ -1,0 +1,73 @@
+defmodule UniboExPoc.PurchasingV3.Party do
+  @moduledoc """
+  V3 供应商主体：增加风险维度用于下单前拦截。
+  """
+  use Ash.Resource,
+    otp_app: :unibo_ex_poc,
+    domain: UniboExPoc.PurchasingV3,
+    data_layer: AshPostgres.DataLayer,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:party_v3)
+
+    queries do
+      get(:get_party_v3, :read)
+      list(:list_parties_v3, :read)
+    end
+
+    mutations do
+      create(:create_party_v3, :create)
+      update(:update_party_v3, :update)
+    end
+  end
+
+  postgres do
+    table("v3_parties")
+    repo(UniboExPoc.Repo)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute :name, :string do
+      allow_nil?(false)
+      public?(true)
+    end
+
+    attribute :status, :atom do
+      constraints(one_of: [:active, :inactive])
+      default(:active)
+      allow_nil?(false)
+      public?(true)
+    end
+
+    attribute :risk_level, :atom do
+      constraints(one_of: [:low, :medium, :high])
+      default(:low)
+      allow_nil?(false)
+      public?(true)
+    end
+
+    attribute :is_blocked, :boolean do
+      default(false)
+      allow_nil?(false)
+      public?(true)
+    end
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:name, :status, :risk_level, :is_blocked])
+    end
+
+    update :update do
+      accept([:name, :status, :risk_level, :is_blocked])
+    end
+  end
+end

--- a/lib/unibo_ex_poc_web/schema.ex
+++ b/lib/unibo_ex_poc_web/schema.ex
@@ -6,7 +6,8 @@ defmodule UniboExPocWeb.Schema do
   """
   use Absinthe.Schema
 
-  use AshGraphql, domains: [UniboExPoc.Purchasing, UniboExPoc.PurchasingV2]
+  use AshGraphql,
+    domains: [UniboExPoc.Purchasing, UniboExPoc.PurchasingV2, UniboExPoc.PurchasingV3]
 
   import_types(Absinthe.Plug.Types)
 

--- a/priv/repo/migrations/20260228052000_add_purchasing_v3_domain.exs
+++ b/priv/repo/migrations/20260228052000_add_purchasing_v3_domain.exs
@@ -1,0 +1,46 @@
+defmodule UniboExPoc.Repo.Migrations.AddPurchasingV3Domain do
+  @moduledoc """
+  V3 采购规则验证表结构：金额分级审批 + 风险供应商。
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create table(:v3_parties, primary_key: false) do
+      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
+      add(:name, :text, null: false)
+      add(:status, :text, null: false, default: "active")
+      add(:risk_level, :text, null: false, default: "low")
+      add(:is_blocked, :boolean, null: false, default: false)
+
+      timestamps(type: :utc_datetime_usec, inserted_at: :inserted_at, updated_at: :updated_at)
+    end
+
+    create table(:v3_orders, primary_key: false) do
+      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
+      add(:order_name, :text, null: false)
+      add(:status, :text, null: false, default: "created")
+      add(:total_amount, :decimal, null: false, default: "0")
+      add(:created_by_id, :uuid, null: false)
+
+      timestamps(type: :utc_datetime_usec, inserted_at: :inserted_at, updated_at: :updated_at)
+
+      add(
+        :supplier_id,
+        references(:v3_parties,
+          column: :id,
+          name: "v3_orders_supplier_id_fkey",
+          type: :uuid,
+          prefix: "public"
+        ),
+        null: false
+      )
+    end
+  end
+
+  def down do
+    drop(constraint(:v3_orders, "v3_orders_supplier_id_fkey"))
+    drop(table(:v3_orders))
+    drop(table(:v3_parties))
+  end
+end

--- a/test/unibo_ex_poc/purchasing_v3/order_rules_test.exs
+++ b/test/unibo_ex_poc/purchasing_v3/order_rules_test.exs
@@ -1,0 +1,109 @@
+defmodule UniboExPoc.PurchasingV3.OrderRulesTest do
+  use UniboExPoc.DataCase, async: false
+
+  alias UniboExPoc.PurchasingV3
+  alias UniboExPoc.PurchasingV3.Actor
+
+  test "小额订单可走普通审批" do
+    supplier = create_supplier!(:low, false)
+    buyer = actor(:buyer)
+
+    {:ok, order} =
+      Ash.create(
+        PurchasingV3.Order,
+        %{order_name: "V3-small", total_amount: Decimal.new("50000"), supplier_id: supplier.id},
+        action: :create,
+        actor: buyer
+      )
+
+    assert order.status == :created
+    assert order.created_by_id == buyer.id
+
+    {:ok, order} = Ash.update(order, %{}, action: :submit, actor: buyer)
+    assert order.status == :submitted
+
+    {:ok, order} = Ash.update(order, %{}, action: :approve, actor: buyer)
+    assert order.status == :approved
+  end
+
+  test "高风险供应商会被拦截" do
+    supplier = create_supplier!(:high, false)
+
+    assert {:error, error} =
+             Ash.create(
+               PurchasingV3.Order,
+               %{
+                 order_name: "V3-risk-high",
+                 total_amount: Decimal.new("1000"),
+                 supplier_id: supplier.id
+               },
+               action: :create,
+               actor: actor(:buyer)
+             )
+
+    assert Exception.message(error) =~ "供应商风险等级过高"
+  end
+
+  test "禁用供应商会被拦截" do
+    supplier = create_supplier!(:low, true)
+
+    assert {:error, error} =
+             Ash.create(
+               PurchasingV3.Order,
+               %{
+                 order_name: "V3-risk-blocked",
+                 total_amount: Decimal.new("1000"),
+                 supplier_id: supplier.id
+               },
+               action: :create,
+               actor: actor(:buyer)
+             )
+
+    assert Exception.message(error) =~ "供应商已被禁用"
+  end
+
+  test "大额订单必须走高级审批" do
+    supplier = create_supplier!(:low, false)
+    buyer = actor(:buyer)
+
+    {:ok, order} =
+      Ash.create(
+        PurchasingV3.Order,
+        %{order_name: "V3-large", total_amount: Decimal.new("100000"), supplier_id: supplier.id},
+        action: :create,
+        actor: buyer
+      )
+
+    {:ok, order} = Ash.update(order, %{}, action: :submit, actor: buyer)
+
+    assert {:error, error} = Ash.update(order, %{}, action: :approve, actor: buyer)
+    assert Exception.message(error) =~ "需走高级审批"
+
+    assert {:error, error} = Ash.update(order, %{}, action: :senior_approve, actor: buyer)
+    assert Exception.message(error) =~ "仅采购主管可执行高级审批"
+
+    {:ok, approved} = Ash.update(order, %{}, action: :senior_approve, actor: actor(:admin))
+    assert approved.status == :approved
+  end
+
+  defp create_supplier!(risk_level, is_blocked) do
+    {:ok, supplier} =
+      Ash.create(
+        PurchasingV3.Party,
+        %{
+          name: "供应商-#{risk_level}-#{is_blocked}",
+          status: :active,
+          risk_level: risk_level,
+          is_blocked: is_blocked
+        },
+        action: :create,
+        authorize?: false
+      )
+
+    supplier
+  end
+
+  defp actor(role) do
+    %Actor{id: Ecto.UUID.generate(), role: role}
+  end
+end

--- a/test/unibo_ex_poc_web/graphql/order_v3_flow_test.exs
+++ b/test/unibo_ex_poc_web/graphql/order_v3_flow_test.exs
@@ -1,0 +1,236 @@
+defmodule UniboExPocWeb.Graphql.OrderV3FlowTest do
+  use UniboExPocWeb.ConnCase, async: false
+
+  test "GraphQL V3：金额分级审批与风险供应商拦截" do
+    buyer_id = Ecto.UUID.generate()
+    admin_id = Ecto.UUID.generate()
+    viewer_id = Ecto.UUID.generate()
+
+    create_party = """
+    mutation CreatePartyV3($input: CreatePartyV3Input!) {
+      createPartyV3(input: $input) {
+        result { id name status riskLevel isBlocked }
+        errors { message fields }
+      }
+    }
+    """
+
+    high_risk_resp =
+      graphql(
+        build_conn(),
+        create_party,
+        %{
+          "input" => %{
+            "name" => "高风险供应商",
+            "status" => "active",
+            "riskLevel" => "high",
+            "isBlocked" => false
+          }
+        },
+        actor_id: admin_id,
+        actor_role: "admin"
+      )
+
+    high_risk_supplier_id = get_in(high_risk_resp, ["data", "createPartyV3", "result", "id"])
+
+    low_risk_resp =
+      graphql(
+        build_conn(),
+        create_party,
+        %{
+          "input" => %{
+            "name" => "低风险供应商",
+            "status" => "active",
+            "riskLevel" => "low",
+            "isBlocked" => false
+          }
+        },
+        actor_id: admin_id,
+        actor_role: "admin"
+      )
+
+    low_risk_supplier_id = get_in(low_risk_resp, ["data", "createPartyV3", "result", "id"])
+
+    create_order = """
+    mutation CreateOrderV3($input: CreateOrderV3Input!) {
+      createOrderV3(input: $input) {
+        result { id status createdById totalAmount }
+        errors { message fields }
+      }
+    }
+    """
+
+    # 高风险供应商：创建失败
+    blocked_resp =
+      graphql(
+        build_conn(),
+        create_order,
+        %{
+          "input" => %{
+            "orderName" => "V3-risk-order",
+            "totalAmount" => "5000",
+            "supplierId" => high_risk_supplier_id
+          }
+        },
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert is_nil(get_in(blocked_resp, ["data", "createOrderV3", "result"]))
+    assert [%{"message" => message}] = get_in(blocked_resp, ["data", "createOrderV3", "errors"])
+    assert message =~ "风险等级过高"
+
+    # viewer：创建失败
+    viewer_resp =
+      graphql(
+        build_conn(),
+        create_order,
+        %{
+          "input" => %{
+            "orderName" => "V3-viewer-order",
+            "totalAmount" => "5000",
+            "supplierId" => low_risk_supplier_id
+          }
+        },
+        actor_id: viewer_id,
+        actor_role: "viewer"
+      )
+
+    assert is_nil(get_in(viewer_resp, ["data", "createOrderV3", "result"]))
+
+    assert [%{"message" => "forbidden"}] =
+             get_in(viewer_resp, ["data", "createOrderV3", "errors"])
+
+    # buyer：小额单正常审批
+    small_resp =
+      graphql(
+        build_conn(),
+        create_order,
+        %{
+          "input" => %{
+            "orderName" => "V3-small-order",
+            "totalAmount" => "50000",
+            "supplierId" => low_risk_supplier_id
+          }
+        },
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    small_order_id = get_in(small_resp, ["data", "createOrderV3", "result", "id"])
+    assert buyer_id == get_in(small_resp, ["data", "createOrderV3", "result", "createdById"])
+
+    submit_order = """
+    mutation SubmitOrderV3($id: ID!) {
+      submitOrderV3(id: $id) {
+        result { id status }
+        errors { message fields }
+      }
+    }
+    """
+
+    submit_small_resp =
+      graphql(build_conn(), submit_order, %{"id" => small_order_id},
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert "submitted" == get_in(submit_small_resp, ["data", "submitOrderV3", "result", "status"])
+
+    approve_order = """
+    mutation ApproveOrderV3($id: ID!) {
+      approveOrderV3(id: $id) {
+        result { id status }
+        errors { message fields }
+      }
+    }
+    """
+
+    approve_small_resp =
+      graphql(build_conn(), approve_order, %{"id" => small_order_id},
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert "approved" ==
+             get_in(approve_small_resp, ["data", "approveOrderV3", "result", "status"])
+
+    # buyer：大额单普通审批被拦截
+    large_resp =
+      graphql(
+        build_conn(),
+        create_order,
+        %{
+          "input" => %{
+            "orderName" => "V3-large-order",
+            "totalAmount" => "100000",
+            "supplierId" => low_risk_supplier_id
+          }
+        },
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    large_order_id = get_in(large_resp, ["data", "createOrderV3", "result", "id"])
+
+    submit_large_resp =
+      graphql(build_conn(), submit_order, %{"id" => large_order_id},
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert "submitted" == get_in(submit_large_resp, ["data", "submitOrderV3", "result", "status"])
+
+    approve_large_resp =
+      graphql(build_conn(), approve_order, %{"id" => large_order_id},
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert is_nil(get_in(approve_large_resp, ["data", "approveOrderV3", "result"]))
+
+    assert [%{"message" => approve_err}] =
+             get_in(approve_large_resp, ["data", "approveOrderV3", "errors"])
+
+    assert approve_err =~ "需走高级审批"
+
+    senior_approve = """
+    mutation SeniorApproveOrderV3($id: ID!) {
+      seniorApproveOrderV3(id: $id) {
+        result { id status }
+        errors { message fields }
+      }
+    }
+    """
+
+    senior_by_buyer_resp =
+      graphql(build_conn(), senior_approve, %{"id" => large_order_id},
+        actor_id: buyer_id,
+        actor_role: "buyer"
+      )
+
+    assert is_nil(get_in(senior_by_buyer_resp, ["data", "seniorApproveOrderV3", "result"]))
+
+    assert [%{"message" => senior_err}] =
+             get_in(senior_by_buyer_resp, ["data", "seniorApproveOrderV3", "errors"])
+
+    assert senior_err =~ "仅采购主管可执行高级审批"
+
+    senior_by_admin_resp =
+      graphql(build_conn(), senior_approve, %{"id" => large_order_id},
+        actor_id: admin_id,
+        actor_role: "admin"
+      )
+
+    assert "approved" ==
+             get_in(senior_by_admin_resp, ["data", "seniorApproveOrderV3", "result", "status"])
+  end
+
+  defp graphql(conn, query, variables, actor_opts) do
+    conn
+    |> put_req_header("x-actor-id", Keyword.fetch!(actor_opts, :actor_id))
+    |> put_req_header("x-actor-role", Keyword.fetch!(actor_opts, :actor_role))
+    |> post("/api/graphql", %{query: query, variables: variables})
+    |> json_response(200)
+  end
+end


### PR DESCRIPTION
## Summary

- 新增 `PurchasingV3` 领域，补齐两条业务规则：
  - 金额分级审批：大额订单不能走普通审批，必须走高级审批
  - 风险供应商拦截：高风险/禁用/非active 供应商禁止下单
- 新增 V3 数据迁移：`v3_parties`、`v3_orders`
- 将 V3 domain 挂载到应用配置与 GraphQL schema
- 增加 Ash 层与 GraphQL 层端到端测试

## Test plan

- `mix test test/unibo_ex_poc/purchasing_v3/order_rules_test.exs test/unibo_ex_poc_web/graphql/order_v3_flow_test.exs`
- `mix test`

Closes #5
