### PR TITLE
feat: 完成 issue #9 最小闭环手工验证

### DIFF
--- a/docs/issue-9-manual-validation.json
+++ b/docs/issue-9-manual-validation.json
@@ -1,0 +1,130 @@
+{
+  "meta": {
+    "generated_at": "2026-02-28T14:29:09.112179Z",
+    "issue": 9
+  },
+  "rules": [
+    {
+      "id": "rule-1",
+      "name": "风险供应商拦截",
+      "positive": {
+        "title": "低风险供应商可下单",
+        "pass": true,
+        "actual": {
+          "data": {
+            "createOrderV3": {
+              "errors": [],
+              "result": {
+                "createdById": "13d37b6a-8800-481c-9138-500c60cbf56d",
+                "id": "0c57dc4b-af23-4009-89c8-6efc0b645e4d",
+                "status": "created",
+                "totalAmount": "5000"
+              }
+            }
+          }
+        },
+        "expected": "创建成功并返回订单ID"
+      },
+      "negative": {
+        "title": "高风险供应商禁止下单",
+        "pass": true,
+        "actual": {
+          "data": {
+            "createOrderV3": {
+              "errors": [
+                {
+                  "fields": [
+                    "supplier_id"
+                  ],
+                  "message": "供应商风险等级过高，禁止下单"
+                }
+              ],
+              "result": null
+            }
+          }
+        },
+        "expected": "创建失败，错误包含“风险等级过高”"
+      }
+    },
+    {
+      "id": "rule-2",
+      "name": "状态流转约束",
+      "positive": {
+        "title": "created -> submitted",
+        "pass": true,
+        "actual": {
+          "data": {
+            "submitOrderV3": {
+              "errors": [],
+              "result": {
+                "id": "0c57dc4b-af23-4009-89c8-6efc0b645e4d",
+                "status": "submitted"
+              }
+            }
+          }
+        },
+        "expected": "提交成功，状态变为submitted"
+      },
+      "negative": {
+        "title": "created 不能直接 approve",
+        "pass": true,
+        "actual": {
+          "data": {
+            "approveOrderV3": {
+              "errors": [
+                {
+                  "fields": [
+                    "status"
+                  ],
+                  "message": "只有已提交订单可以审批"
+                }
+              ],
+              "result": null
+            }
+          }
+        },
+        "expected": "审批失败，错误包含“只有已提交订单可以审批”"
+      }
+    },
+    {
+      "id": "rule-3",
+      "name": "大额单高级审批",
+      "positive": {
+        "title": "admin 可执行 senior approve",
+        "pass": true,
+        "actual": {
+          "data": {
+            "seniorApproveOrderV3": {
+              "errors": [],
+              "result": {
+                "id": "fe7e1c37-305c-4e36-962e-5e1b064319e1",
+                "status": "approved"
+              }
+            }
+          }
+        },
+        "expected": "高级审批成功，状态变为approved"
+      },
+      "negative": {
+        "title": "buyer 不能普通审批大额单",
+        "pass": true,
+        "actual": {
+          "data": {
+            "approveOrderV3": {
+              "errors": [
+                {
+                  "fields": [
+                    "total_amount"
+                  ],
+                  "message": "订单金额达到分级阈值，需走高级审批"
+                }
+              ],
+              "result": null
+            }
+          }
+        },
+        "expected": "普通审批失败，错误包含“需走高级审批”"
+      }
+    }
+  ]
+}

--- a/docs/issue-9-manual-validation.md
+++ b/docs/issue-9-manual-validation.md
@@ -1,0 +1,68 @@
+# Issue #9 手工验证记录（最小闭环）
+
+## 执行时间
+
+- 2026-02-28
+
+## 场景 A：编译产物接入可编译
+
+- 命令 1：`scripts/verify_codegen_poc.sh`
+- 预期：自动链路通过，生成 Ash 产物
+- 实际：
+  - `import` 成功（112 实体）
+  - `compile` 成功（113 个 `.ex` 文件，含 1 个 Domain）
+  - smoke check 通过
+- 结论：通过
+
+- 命令 2：`mix compile`
+- 预期：PoC 工程可编译
+- 实际：编译成功（`Generated unibo_ex_poc app`）
+- 结论：通过
+
+## 场景 B/C/D：GraphQL 规则手工验证
+
+- 命令：`mix run scripts/manual_verify_issue9.exs`
+- 产物：`docs/issue-9-manual-validation.json`
+
+### 规则 1：风险供应商拦截
+
+- 正例输入：低风险供应商创建订单
+- 预期：创建成功，返回订单 ID
+- 实际：`createOrderV3.result.id` 返回非空，`errors` 为空
+- 结论：通过
+
+- 反例输入：高风险供应商创建订单
+- 预期：创建失败，提示风险等级过高
+- 实际：`createOrderV3.result = null`，错误为“供应商风险等级过高，禁止下单”
+- 结论：通过
+
+### 规则 2：状态流转约束
+
+- 正例输入：`created -> submit`
+- 预期：状态变为 `submitted`
+- 实际：`submitOrderV3.result.status = submitted`
+- 结论：通过
+
+- 反例输入：`created -> approve`（未提交直接审批）
+- 预期：审批失败
+- 实际：`approveOrderV3.result = null`，错误为“只有已提交订单可以审批”
+- 结论：通过
+
+### 规则 3：大额单高级审批
+
+- 正例输入：`admin` 执行 `seniorApproveOrderV3`
+- 预期：高级审批成功，状态 `approved`
+- 实际：`seniorApproveOrderV3.result.status = approved`
+- 结论：通过
+
+- 反例输入：`buyer` 对大额单执行普通 `approveOrderV3`
+- 预期：普通审批失败
+- 实际：`approveOrderV3.result = null`，错误为“订单金额达到分级阈值，需走高级审批”
+- 结论：通过
+
+## 验收结论
+
+- `mix compile` 通过
+- 3 条核心规则均完成“正例 + 反例”手工验证
+- 每个场景均有输入/预期/实际/结论记录
+- 最小验证模板已沉淀（脚本 + JSON 结果 + 本文档）

--- a/scripts/manual_verify_issue9.exs
+++ b/scripts/manual_verify_issue9.exs
@@ -1,0 +1,251 @@
+defmodule UniboExPoc.ManualVerifyIssue9 do
+  @moduledoc false
+
+  alias UniboExPoc.PurchasingV2.Actor
+  alias UniboExPoc.Repo
+
+  require Logger
+
+  @create_party """
+  mutation CreatePartyV3($input: CreatePartyV3Input!) {
+    createPartyV3(input: $input) {
+      result { id name status riskLevel isBlocked }
+      errors { message fields }
+    }
+  }
+  """
+
+  @create_order """
+  mutation CreateOrderV3($input: CreateOrderV3Input!) {
+    createOrderV3(input: $input) {
+      result { id status createdById totalAmount }
+      errors { message fields }
+    }
+  }
+  """
+
+  @submit_order """
+  mutation SubmitOrderV3($id: ID!) {
+    submitOrderV3(id: $id) {
+      result { id status }
+      errors { message fields }
+    }
+  }
+  """
+
+  @approve_order """
+  mutation ApproveOrderV3($id: ID!) {
+    approveOrderV3(id: $id) {
+      result { id status }
+      errors { message fields }
+    }
+  }
+  """
+
+  @senior_approve_order """
+  mutation SeniorApproveOrderV3($id: ID!) {
+    seniorApproveOrderV3(id: $id) {
+      result { id status }
+      errors { message fields }
+    }
+  }
+  """
+
+  def run do
+    Logger.configure(level: :error)
+    reset_v3_tables!()
+
+    admin = %Actor{id: Ecto.UUID.generate(), role: :admin}
+    buyer = %Actor{id: Ecto.UUID.generate(), role: :buyer}
+
+    high_supplier_resp =
+      gql(@create_party, %{
+        "input" => %{
+          "name" => "手工验证-高风险供应商",
+          "status" => "active",
+          "riskLevel" => "high",
+          "isBlocked" => false
+        }
+      }, admin)
+
+    low_supplier_resp =
+      gql(@create_party, %{
+        "input" => %{
+          "name" => "手工验证-低风险供应商",
+          "status" => "active",
+          "riskLevel" => "low",
+          "isBlocked" => false
+        }
+      }, admin)
+
+    high_supplier_id = get_in(high_supplier_resp, [:data, "createPartyV3", "result", "id"])
+    low_supplier_id = get_in(low_supplier_resp, [:data, "createPartyV3", "result", "id"])
+
+    # 规则1：供应商风险控制（正/反）
+    rule1_positive =
+      gql(@create_order, %{
+        "input" => %{
+          "orderName" => "ISSUE9-R1-POS",
+          "totalAmount" => "5000",
+          "supplierId" => low_supplier_id
+        }
+      }, buyer)
+
+    rule1_negative =
+      gql(@create_order, %{
+        "input" => %{
+          "orderName" => "ISSUE9-R1-NEG",
+          "totalAmount" => "5000",
+          "supplierId" => high_supplier_id
+        }
+      }, buyer)
+
+    rule1_pos_order_id = get_in(rule1_positive, [:data, "createOrderV3", "result", "id"])
+
+    # 规则2：状态流转约束（正/反）
+    rule2_positive = gql(@submit_order, %{"id" => rule1_pos_order_id}, buyer)
+
+    rule2_negative_seed =
+      gql(@create_order, %{
+        "input" => %{
+          "orderName" => "ISSUE9-R2-NEG-SEED",
+          "totalAmount" => "5000",
+          "supplierId" => low_supplier_id
+        }
+      }, buyer)
+
+    rule2_negative_order_id =
+      get_in(rule2_negative_seed, [:data, "createOrderV3", "result", "id"])
+
+    rule2_negative = gql(@approve_order, %{"id" => rule2_negative_order_id}, buyer)
+
+    # 规则3：大额单高级审批（正/反）
+    rule3_seed =
+      gql(@create_order, %{
+        "input" => %{
+          "orderName" => "ISSUE9-R3-SEED",
+          "totalAmount" => "100000",
+          "supplierId" => low_supplier_id
+        }
+      }, buyer)
+
+    rule3_order_id = get_in(rule3_seed, [:data, "createOrderV3", "result", "id"])
+    _rule3_submit = gql(@submit_order, %{"id" => rule3_order_id}, buyer)
+
+    rule3_negative = gql(@approve_order, %{"id" => rule3_order_id}, buyer)
+    rule3_positive = gql(@senior_approve_order, %{"id" => rule3_order_id}, admin)
+
+    report = %{
+      meta: %{
+        generated_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+        issue: 9
+      },
+      rules: [
+        %{
+          id: "rule-1",
+          name: "风险供应商拦截",
+          positive: scenario(
+            "低风险供应商可下单",
+            "创建成功并返回订单ID",
+            rule1_positive,
+            fn resp ->
+              is_binary(get_in(resp, [:data, "createOrderV3", "result", "id"])) and
+                is_nil(first_error_message(resp, "createOrderV3"))
+            end
+          ),
+          negative: scenario(
+            "高风险供应商禁止下单",
+            "创建失败，错误包含“风险等级过高”",
+            rule1_negative,
+            fn resp ->
+              is_nil(get_in(resp, [:data, "createOrderV3", "result"])) and
+                String.contains?(
+                  first_error_message(resp, "createOrderV3") || "",
+                  "风险等级过高"
+                )
+            end
+          )
+        },
+        %{
+          id: "rule-2",
+          name: "状态流转约束",
+          positive: scenario(
+            "created -> submitted",
+            "提交成功，状态变为submitted",
+            rule2_positive,
+            fn resp -> get_in(resp, [:data, "submitOrderV3", "result", "status"]) == "submitted" end
+          ),
+          negative: scenario(
+            "created 不能直接 approve",
+            "审批失败，错误包含“只有已提交订单可以审批”",
+            rule2_negative,
+            fn resp ->
+              is_nil(get_in(resp, [:data, "approveOrderV3", "result"])) and
+                String.contains?(
+                  first_error_message(resp, "approveOrderV3") || "",
+                  "只有已提交订单可以审批"
+                )
+            end
+          )
+        },
+        %{
+          id: "rule-3",
+          name: "大额单高级审批",
+          positive: scenario(
+            "admin 可执行 senior approve",
+            "高级审批成功，状态变为approved",
+            rule3_positive,
+            fn resp ->
+              get_in(resp, [:data, "seniorApproveOrderV3", "result", "status"]) == "approved"
+            end
+          ),
+          negative: scenario(
+            "buyer 不能普通审批大额单",
+            "普通审批失败，错误包含“需走高级审批”",
+            rule3_negative,
+            fn resp ->
+              is_nil(get_in(resp, [:data, "approveOrderV3", "result"])) and
+                String.contains?(
+                  first_error_message(resp, "approveOrderV3") || "",
+                  "需走高级审批"
+                )
+            end
+          )
+        }
+      ]
+    }
+
+    IO.puts(Jason.encode!(report, pretty: true))
+  end
+
+  defp scenario(title, expected, actual, pass_fun) do
+    %{
+      title: title,
+      expected: expected,
+      actual: actual,
+      pass: pass_fun.(actual)
+    }
+  end
+
+  defp gql(query, variables, actor) do
+    case Absinthe.run(query, UniboExPocWeb.Schema, variables: variables, context: %{actor: actor}) do
+      {:ok, response} -> response
+      {:error, errors} -> %{"errors" => inspect(errors)}
+    end
+  end
+
+  defp first_error_message(resp, field_name) do
+    resp
+    |> get_in([:data, field_name, "errors"])
+    |> case do
+      [%{"message" => message} | _] -> message
+      _ -> nil
+    end
+  end
+
+  defp reset_v3_tables! do
+    Ecto.Adapters.SQL.query!(Repo, "TRUNCATE TABLE v3_orders, v3_parties RESTART IDENTITY CASCADE", [])
+  end
+end
+
+UniboExPoc.ManualVerifyIssue9.run()

--- a/scripts/verify_codegen_poc.sh
+++ b/scripts/verify_codegen_poc.sh
@@ -51,8 +51,15 @@ if [[ "$FILE_COUNT" -lt 50 ]]; then
   exit 1
 fi
 
-if ! grep -q "defmodule UniboExPoc.Purchasing.Generated" "$ASH_OUT/generated.ex"; then
-  echo "错误: generated.ex 未生成 domain 模块" >&2
+# 编译器可能调整 domain 文件名，这里按 "use Ash.Domain + 模块前缀" 判定
+DOMAIN_FILE="$(rg -l "use Ash.Domain" "$ASH_OUT"/*.ex | head -n 1 || true)"
+if [[ -z "${DOMAIN_FILE:-}" ]]; then
+  echo "错误: 未生成 Ash.Domain 模块" >&2
+  exit 1
+fi
+
+if ! grep -q "defmodule UniboExPoc.Purchasing.Generated" "$DOMAIN_FILE"; then
+  echo "错误: Domain 模块前缀不符合预期: $DOMAIN_FILE" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- 修复 `scripts/verify_codegen_poc.sh` 对 domain 文件名的硬编码检查，改为按 `Ash.Domain + 模块前缀` 校验
- 新增 `scripts/manual_verify_issue9.exs`，可一键执行 3 条核心规则正反例 GraphQL 手工验证
- 新增验证产物：
  - `docs/issue-9-manual-validation.json`
  - `docs/issue-9-manual-validation.md`

## Test plan
- [x] `scripts/verify_codegen_poc.sh`
- [x] `mix compile`
- [x] `mix run scripts/manual_verify_issue9.exs`

Closes #9
