### PR TITLE
feat: Travel YAML 补充 determine_actions 跨聚合声明 (#113)

### DIFF
--- a/travel/models/travel.ubo.yaml
+++ b/travel/models/travel.ubo.yaml
@@ -1855,6 +1855,21 @@ entities:
           - action: mark_order_failed
             trigger_event: travel.order.failed
           - action: destroy
+    determine_actions:
+      - name: trigger_fulfillment_creation
+        scope: cross_aggregate
+        mode: derive_only
+        phase: post_commit
+        read_set:
+          - status
+          - product_type
+      - name: trigger_policy_check
+        scope: cross_aggregate
+        mode: derive_only
+        phase: post_commit
+        read_set:
+          - product_type
+          - total_amount
     business_rules:
       - id: TRAVEL-ORDER-01
         description: TravelOrder 是统一订单聚合，不按 hotel/flight/vacation/train 各自拆单独订单聚合
@@ -2267,6 +2282,15 @@ entities:
             trigger_event: travel.change_order.rejected
           - action: complete
             trigger_event: travel.change_order.completed
+    determine_actions:
+      - name: notify_order_change_approved
+        scope: cross_aggregate
+        mode: async_write_back
+        phase: post_commit
+        read_set:
+          - original_order.status
+        write_set:
+          - status
     business_rules:
       - id: TRAVEL-CHANGE-ORDER-01
         description: TravelChangeOrder 通过 original_order_id 关联原订单，new_offer_id 为字符串引用，不做跨实体外键
@@ -2386,6 +2410,15 @@ entities:
             trigger_event: travel.refund_order.rejected
           - action: refund
             trigger_event: travel.refund_order.refunded
+    determine_actions:
+      - name: notify_order_refund_approved
+        scope: cross_aggregate
+        mode: async_write_back
+        phase: post_commit
+        read_set:
+          - original_order.status
+        write_set:
+          - status
     business_rules:
       - id: TRAVEL-REFUND-ORDER-01
         description: TravelRefundOrder 通过 original_order_id 关联原订单，实际退款动作可由 Payment 域处理


### PR DESCRIPTION
## Summary

为 3 个 Travel 实体补充 4 个 `determine_actions scope: cross_aggregate` 声明：

| 实体 | determine_action | mode | read_set | write_set |
|------|-----------------|------|----------|-----------|
| TravelOrder | trigger_fulfillment_creation | derive_only | status, product_type | — |
| TravelOrder | trigger_policy_check | derive_only | product_type, total_amount | — |
| TravelChangeOrder | notify_order_change_approved | async_write_back | original_order.status | status |
| TravelRefundOrder | notify_order_refund_approved | async_write_back | original_order.status | status |

全部符合 R38/R39/R39.1 规则。

配合 unibo#1304（PR #1312 已合并），`export-bdd-source --risk-templates on` 额外生成 16 个 determination BDD 场景。

Closes #113

## Test plan

- [x] YAML 格式正确
- [x] R39 门禁合规（cross_aggregate 无 sync_write_back，async 有非空 write_set）
- [x] export-bdd-source 生成 461 个源（含 16 determination）

🤖 Generated with [Claude Code](https://claude.com/claude-code)