### PR TITLE
fix: add hospital scheduling list base template

### DIFF
--- a/hospital_scheduling/pages/scheduling/admin/base_list_report.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/base_list_report.dsl
@@ -1,0 +1,38 @@
+[PAGE: base_list]
+  ATTR: Title("列表")
+  [SECTION: header]
+    [FLEX: header_bar]
+      { Justify: "Between", Align: "Center" }
+      [TEXT: page_title]
+        ATTR: Variant("title")
+        CONTENT: "{{page_title|数据列表}}"
+      [BUTTON: create_btn]
+        ATTR: Variant("primary"), Click("navigate_create")
+        CONTENT: "新建"
+  [SECTION: filter_section]
+    [CARD: filter_card]
+      [CARD_CONTENT: filter_content]
+        [FLEX: filter_row]
+          { Gap: 4, Align: "Center" }
+          [TEXT: filter_placeholder]
+            CONTENT: "筛选区域"
+          [BUTTON: filter_submit]
+            ATTR: Variant("secondary"), Click("filter_submit")
+            CONTENT: "查询"
+  [SECTION: table_section]
+    [TABLE: data_table]
+      [TABLE_HEADER: data_header]
+        [TABLE_ROW: header_row]
+          [TABLE_HEAD: th_placeholder]
+            CONTENT: "数据列"
+      [TABLE_BODY: data_body]
+        [TEXT: body_placeholder]
+          CONTENT: "数据行"
+  [SECTION: empty_section]
+    [IF: rows_empty]
+      [EMPTY_STATE: no_data]
+        ATTR: Description("暂无数据")
+    [/IF]
+  [SECTION: footer]
+    [TEXT: pagination]
+      CONTENT: "分页"


### PR DESCRIPTION
Summary:
- add project-side `base_list_report.dsl` for hospital_scheduling hand-written list pages
- unblock `scheduling_period_list` and `scheduling_constraint_list` under `--pages-dir hospital_scheduling/pages`

Test plan:
- cargo run --manifest-path /home/wangbo/document/unibo/Cargo.toml -- compile-frontend --models /home/wangbo/document/unibo_ex_poc-feat-114/hospital_scheduling/models --stitch-bin /home/wangbo/document/stitch/dist/bin/stitch.js --output /tmp/unibo-hs-frontend-check-fix --pages-dir /home/wangbo/document/unibo_ex_poc-feat-114/hospital_scheduling/pages
- cd /home/wangbo/document/unibo_ex_poc-feat-114/hospital_scheduling && MIX_ENV=test mix test test/hospital_scheduling_web/live/page_host_runtime_test.exs test/integration/stitch_backend_test.exs

Closes #114