### PR TITLE
feat: support optional travel approval flow

### DIFF
--- a/travel/lib/unibo_ex_poc/travel/policy_engine.ex
+++ b/travel/lib/unibo_ex_poc/travel/policy_engine.ex
@@ -65,6 +65,7 @@ defmodule UniboExPoc.Travel.PolicyEngine do
       exceed_amount: nil,
       exceed_ratio: nil,
       exceed_strategy: nil,
+      approval_mode: nil,
       exceed_reason: nil,
       personal_pay_amount: nil
     }
@@ -73,6 +74,7 @@ defmodule UniboExPoc.Travel.PolicyEngine do
   def check_compliance(order_params, policy) do
     actual = order_params[:actual_amount] || 0
     limit = policy.max_amount || 0
+    approval_mode = policy.approval_mode |> to_string()
 
     if actual <= limit do
       %{
@@ -82,6 +84,7 @@ defmodule UniboExPoc.Travel.PolicyEngine do
         exceed_amount: 0,
         exceed_ratio: "0%",
         exceed_strategy: to_string(policy.exceed_strategy),
+        approval_mode: approval_mode,
         exceed_reason: nil,
         personal_pay_amount: nil
       }
@@ -106,6 +109,7 @@ defmodule UniboExPoc.Travel.PolicyEngine do
         exceed_amount: exceed,
         exceed_ratio: "#{ratio}%",
         exceed_strategy: to_string(policy.exceed_strategy),
+        approval_mode: approval_mode,
         exceed_reason: nil,
         personal_pay_amount: personal_pay
       }
@@ -130,6 +134,14 @@ defmodule UniboExPoc.Travel.PolicyEngine do
 
   def apply_strategy(%{check_result: :exceeded, exceed_strategy: "require_reason"}) do
     {:ok, :require_reason}
+  end
+
+  def apply_strategy(%{
+        check_result: :exceeded,
+        exceed_strategy: "require_approval",
+        approval_mode: "none"
+      }) do
+    {:ok, :proceed}
   end
 
   def apply_strategy(%{check_result: :exceeded, exceed_strategy: "require_approval"} = check) do

--- a/travel/lib/unibo_ex_poc/travel/travel_change_order.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_change_order.ex
@@ -1,12 +1,14 @@
-# Workflow: change_order_lifecycle — 改签单生命周期：pending → approved → completed，pending → rejected
+# Workflow: change_order_lifecycle — 改签单生命周期：审批开启时 pending → approved → completed / rejected；审批关闭时 pending → completed
 # ```mermaid
 # stateDiagram-v2
 #   [*] --> create
 #   create --> approve
 #   create --> reject
+#   create --> complete_direct
 #   approve --> complete
 #   reject --> [*] : rejected
 #   complete --> [*] : completed
+#   complete_direct --> [*] : completed
 # ```
 defmodule UniboExPoc.Travel.TravelChangeOrder do
   use Ash.Resource,
@@ -39,6 +41,7 @@ defmodule UniboExPoc.Travel.TravelChangeOrder do
       update :approve_travel_travel_change_order, :approve
       update :reject_travel_travel_change_order, :reject
       update :complete_travel_travel_change_order, :complete
+      update :complete_direct_travel_travel_change_order, :complete_direct
     end
 
   end
@@ -66,6 +69,12 @@ defmodule UniboExPoc.Travel.TravelChangeOrder do
       default :pending
       public? true
     end
+    attribute :approval_mode, :atom do
+      constraints one_of: [:none, :self, :oa]
+      default :self
+      public? true
+      description "审批模式快照；none 表示跳过审批，self/oa 表示进入审批流"
+    end
     create_timestamp :inserted_at
     update_timestamp :updated_at
   end
@@ -82,7 +91,7 @@ defmodule UniboExPoc.Travel.TravelChangeOrder do
     create :create do
       description "Create Travel Change Order via Create. doc_url: graphql://contract/travel/create_travel_travel_change_order"
       primary? true
-      accept [:original_order_id, :change_reason, :price_difference, :change_fee, :new_offer_id]
+      accept [:original_order_id, :change_reason, :price_difference, :change_fee, :new_offer_id, :approval_mode]
       argument :original_order_id, :uuid, allow_nil?: false
       change manage_relationship(:original_order_id, :original_order, type: :append, on_lookup: :relate)
       validate present(:original_order_id)
@@ -131,6 +140,58 @@ defmodule UniboExPoc.Travel.TravelChangeOrder do
       end
       # message: "只有 approved 改签单可以完成"
       change set_attribute(:status, :completed)
+      require_atomic? false
+    end
+    update :complete_direct do
+      description "Update Travel Change Order via Complete Direct. doc_url: graphql://contract/travel/complete_direct_travel_travel_change_order"
+      accept []
+      change fn changeset, _ctx ->
+        current = Ash.Changeset.get_attribute(changeset, :approval_mode)
+        if current == :none do
+          changeset
+        else
+          Ash.Changeset.add_error(changeset, Ash.Error.Changes.InvalidAttribute.exception(field: :approval_mode, message: "must equal %{value}", vars: %{value: :none}))
+        end
+      end
+      # message: "只有关闭审批的改签单可以直接完成"
+      change fn changeset, _ctx ->
+        current = Ash.Changeset.get_attribute(changeset, :status)
+        if current == :pending do
+          changeset
+        else
+          Ash.Changeset.add_error(changeset, Ash.Error.Changes.InvalidAttribute.exception(field: :status, message: "must equal %{value}", vars: %{value: :pending}))
+        end
+      end
+      # message: "关闭审批时，pending 改签单可直接完成"
+      change set_attribute(:status, :completed)
+      require_atomic? false
+    end
+
+    update :notify_order_change_approved do
+      accept []
+      # determination semantics: phase=post_commit, scope=cross_aggregate, mode=async_write_back
+      # 异步写回：通过 AsyncRuntime.Queue 进入 outbox 风格队列
+      change fn changeset, _ctx ->
+        queue_module = UniboExPoc.AsyncRuntime.Queue
+        record_id = changeset.data && changeset.data.id
+        dedup_key = "determination:travel_change_order:notify_order_change_approved:#{inspect(record_id)}"
+        payload = %{
+          "entity" => "travel_change_order",
+          "determination" => "notify_order_change_approved",
+          "scope" => "cross_aggregate",
+          "mode" => "async_write_back",
+          "record_id" => record_id
+        }
+        if Code.ensure_loaded?(queue_module) and function_exported?(queue_module, :enqueue, 1) do
+          case queue_module.enqueue(%{kind: "determination_async_write_back", dedup_key: dedup_key, payload: payload}) do
+            {:ok, _task} -> changeset
+            {:ok, :duplicate} -> changeset
+            {:error, reason} -> Ash.Changeset.add_error(changeset, "async determination enqueue failed: #{inspect(reason)}")
+          end
+        else
+          Ash.Changeset.add_error(changeset, "async runtime queue unavailable")
+        end
+      end
       require_atomic? false
     end
   end

--- a/travel/lib/unibo_ex_poc/travel/travel_change_order_notifier.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_change_order_notifier.ex
@@ -7,6 +7,7 @@ defmodule UniboExPoc.Travel.TravelChangeOrder.Notifier do
       :approve -> "travel.change_order.approved"
       :reject -> "travel.change_order.rejected"
       :complete -> "travel.change_order.completed"
+      :complete_direct -> "travel.change_order.completed"
       _ -> nil
     end
 

--- a/travel/lib/unibo_ex_poc/travel/travel_policy.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_policy.ex
@@ -87,6 +87,12 @@ defmodule UniboExPoc.Travel.TravelPolicy do
       public? true
       description "超标处理策略"
     end
+    attribute :approval_mode, :atom do
+      constraints one_of: [:none, :self, :oa]
+      default :self
+      public? true
+      description "审批模式；none 表示关闭审批，self/oa 表示进入对应审批流"
+    end
     attribute :personal_pay_ratio, :integer do
       public? true
       description "个人支付比例 0-100"
@@ -109,7 +115,7 @@ defmodule UniboExPoc.Travel.TravelPolicy do
     create :create do
       description "Create Travel Policy via Create. doc_url: graphql://contract/travel/create_travel_travel_policy"
       primary? true
-      accept [:policy_name, :product_type, :employee_level, :city_tier, :season, :max_amount, :cabin_class_limit, :hotel_star_limit, :exceed_strategy, :personal_pay_ratio, :enterprise_id]
+      accept [:policy_name, :product_type, :employee_level, :city_tier, :season, :max_amount, :cabin_class_limit, :hotel_star_limit, :exceed_strategy, :approval_mode, :personal_pay_ratio, :enterprise_id]
       validate present(:policy_name)
       validate present(:product_type)
       validate present(:exceed_strategy)
@@ -117,7 +123,7 @@ defmodule UniboExPoc.Travel.TravelPolicy do
     update :update do
       description "Update Travel Policy via Update. doc_url: graphql://contract/travel/update_travel_travel_policy"
       primary? true
-      accept [:policy_name, :season, :max_amount, :cabin_class_limit, :hotel_star_limit, :exceed_strategy, :personal_pay_ratio]
+      accept [:policy_name, :season, :max_amount, :cabin_class_limit, :hotel_star_limit, :exceed_strategy, :approval_mode, :personal_pay_ratio]
       require_atomic? false
     end
     update :activate do

--- a/travel/lib/unibo_ex_poc/travel/travel_policy_check.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_policy_check.ex
@@ -69,6 +69,12 @@ defmodule UniboExPoc.Travel.TravelPolicyCheck do
       public? true
       description "审批请求ID（不做跨域外键）"
     end
+    attribute :approval_mode, :atom do
+      constraints one_of: [:none, :self, :oa]
+      default :self
+      public? true
+      description "命中政策时的审批模式快照"
+    end
     create_timestamp :inserted_at
     update_timestamp :updated_at
   end
@@ -89,7 +95,7 @@ defmodule UniboExPoc.Travel.TravelPolicyCheck do
     create :create do
       description "Create Travel Policy Check via Create. doc_url: graphql://contract/travel/create_travel_travel_policy_check"
       primary? true
-      accept [:order_id, :policy_id, :check_result, :policy_amount, :actual_amount, :exceed_amount, :exceed_ratio, :exceed_strategy, :exceed_reason, :personal_pay_amount, :approval_request_id]
+      accept [:order_id, :policy_id, :check_result, :policy_amount, :actual_amount, :exceed_amount, :exceed_ratio, :exceed_strategy, :exceed_reason, :personal_pay_amount, :approval_request_id, :approval_mode]
       argument :order_id, :uuid, allow_nil?: false
       change manage_relationship(:order_id, :order, type: :append, on_lookup: :relate)
       argument :policy_id, :uuid, allow_nil?: false

--- a/travel/lib/unibo_ex_poc/travel/travel_refund_order.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_refund_order.ex
@@ -1,12 +1,14 @@
-# Workflow: refund_order_lifecycle — 退票单生命周期：pending → approved → refunded，pending → rejected
+# Workflow: refund_order_lifecycle — 退票单生命周期：审批开启时 pending → approved → refunded / rejected；审批关闭时 pending → refunded
 # ```mermaid
 # stateDiagram-v2
 #   [*] --> create
 #   create --> approve
 #   create --> reject
+#   create --> refund_direct
 #   approve --> refund
 #   reject --> [*] : rejected
 #   refund --> [*] : refunded
+#   refund_direct --> [*] : refunded
 # ```
 defmodule UniboExPoc.Travel.TravelRefundOrder do
   use Ash.Resource,
@@ -39,6 +41,7 @@ defmodule UniboExPoc.Travel.TravelRefundOrder do
       update :approve_travel_travel_refund_order, :approve
       update :reject_travel_travel_refund_order, :reject
       update :refund_travel_travel_refund_order, :refund
+      update :refund_direct_travel_travel_refund_order, :refund_direct
     end
 
   end
@@ -62,6 +65,12 @@ defmodule UniboExPoc.Travel.TravelRefundOrder do
       default :pending
       public? true
     end
+    attribute :approval_mode, :atom do
+      constraints one_of: [:none, :self, :oa]
+      default :self
+      public? true
+      description "审批模式快照；none 表示跳过审批，self/oa 表示进入审批流"
+    end
     create_timestamp :inserted_at
     update_timestamp :updated_at
   end
@@ -78,7 +87,7 @@ defmodule UniboExPoc.Travel.TravelRefundOrder do
     create :create do
       description "Create Travel Refund Order via Create. doc_url: graphql://contract/travel/create_travel_travel_refund_order"
       primary? true
-      accept [:original_order_id, :refund_reason, :refund_fee, :refund_amount]
+      accept [:original_order_id, :refund_reason, :refund_fee, :refund_amount, :approval_mode]
       argument :original_order_id, :uuid, allow_nil?: false
       change manage_relationship(:original_order_id, :original_order, type: :append, on_lookup: :relate)
       validate present(:original_order_id)
@@ -127,6 +136,58 @@ defmodule UniboExPoc.Travel.TravelRefundOrder do
       end
       # message: "只有 approved 退票单可以执行退款"
       change set_attribute(:status, :refunded)
+      require_atomic? false
+    end
+    update :refund_direct do
+      description "Update Travel Refund Order via Refund Direct. doc_url: graphql://contract/travel/refund_direct_travel_travel_refund_order"
+      accept []
+      change fn changeset, _ctx ->
+        current = Ash.Changeset.get_attribute(changeset, :approval_mode)
+        if current == :none do
+          changeset
+        else
+          Ash.Changeset.add_error(changeset, Ash.Error.Changes.InvalidAttribute.exception(field: :approval_mode, message: "must equal %{value}", vars: %{value: :none}))
+        end
+      end
+      # message: "只有关闭审批的退票单可以直接退款"
+      change fn changeset, _ctx ->
+        current = Ash.Changeset.get_attribute(changeset, :status)
+        if current == :pending do
+          changeset
+        else
+          Ash.Changeset.add_error(changeset, Ash.Error.Changes.InvalidAttribute.exception(field: :status, message: "must equal %{value}", vars: %{value: :pending}))
+        end
+      end
+      # message: "关闭审批时，pending 退票单可直接退款"
+      change set_attribute(:status, :refunded)
+      require_atomic? false
+    end
+
+    update :notify_order_refund_approved do
+      accept []
+      # determination semantics: phase=post_commit, scope=cross_aggregate, mode=async_write_back
+      # 异步写回：通过 AsyncRuntime.Queue 进入 outbox 风格队列
+      change fn changeset, _ctx ->
+        queue_module = UniboExPoc.AsyncRuntime.Queue
+        record_id = changeset.data && changeset.data.id
+        dedup_key = "determination:travel_refund_order:notify_order_refund_approved:#{inspect(record_id)}"
+        payload = %{
+          "entity" => "travel_refund_order",
+          "determination" => "notify_order_refund_approved",
+          "scope" => "cross_aggregate",
+          "mode" => "async_write_back",
+          "record_id" => record_id
+        }
+        if Code.ensure_loaded?(queue_module) and function_exported?(queue_module, :enqueue, 1) do
+          case queue_module.enqueue(%{kind: "determination_async_write_back", dedup_key: dedup_key, payload: payload}) do
+            {:ok, _task} -> changeset
+            {:ok, :duplicate} -> changeset
+            {:error, reason} -> Ash.Changeset.add_error(changeset, "async determination enqueue failed: #{inspect(reason)}")
+          end
+        else
+          Ash.Changeset.add_error(changeset, "async runtime queue unavailable")
+        end
+      end
       require_atomic? false
     end
   end

--- a/travel/lib/unibo_ex_poc/travel/travel_refund_order_notifier.ex
+++ b/travel/lib/unibo_ex_poc/travel/travel_refund_order_notifier.ex
@@ -7,6 +7,7 @@ defmodule UniboExPoc.Travel.TravelRefundOrder.Notifier do
       :approve -> "travel.refund_order.approved"
       :reject -> "travel.refund_order.rejected"
       :refund -> "travel.refund_order.refunded"
+      :refund_direct -> "travel.refund_order.refunded"
       _ -> nil
     end
 

--- a/travel/lib/unibo_ex_poc/travel/workflows/travel_change_order_change_order_lifecycle.ex
+++ b/travel/lib/unibo_ex_poc/travel/workflows/travel_change_order_change_order_lifecycle.ex
@@ -7,11 +7,11 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
   alias UniboExPoc.Travel.TravelChangeOrder
 
   def steps do
-    [:s1_create, :s2_approve, :s3_reject, :s4_complete]
+    [:s1_create, :s2_approve, :s3_reject, :s4_complete, :s5_complete_direct]
   end
 
   @workflow_semantics_json ~S"""
-{"steps":[{"idempotency_key":null,"next":["approve","reject"],"next_step_ids":["s2_approve","s3_reject"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"create","step_id":"s1_create"},{"idempotency_key":null,"next":["complete"],"next_step_ids":["s4_complete"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"approve","step_id":"s2_approve"},{"idempotency_key":null,"next":["complete"],"next_step_ids":["s4_complete"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"reject","step_id":"s3_reject"},{"idempotency_key":null,"next":[],"next_step_ids":[],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"complete","step_id":"s4_complete"}],"workflow":"change_order_lifecycle"}
+{"steps":[{"idempotency_key":null,"next":["approve","reject","complete_direct"],"next_step_ids":["s2_approve","s3_reject","s5_complete_direct"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"create","step_id":"s1_create"},{"idempotency_key":null,"next":["complete"],"next_step_ids":["s4_complete"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"approve","step_id":"s2_approve"},{"idempotency_key":null,"next":["complete"],"next_step_ids":["s4_complete"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"reject","step_id":"s3_reject"},{"idempotency_key":null,"next":["complete_direct"],"next_step_ids":["s5_complete_direct"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"complete","step_id":"s4_complete"},{"idempotency_key":null,"next":[],"next_step_ids":[],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"complete_direct","step_id":"s5_complete_direct"}],"workflow":"change_order_lifecycle"}
 """
   def workflow_semantics_json, do: String.trim(@workflow_semantics_json)
 
@@ -106,6 +106,8 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
         Ash.update(Ash.Changeset.for_update(record, :reject, params), ash_opts)
       :s4_complete ->
         Ash.update(Ash.Changeset.for_update(record, :complete, params), ash_opts)
+      :s5_complete_direct ->
+        Ash.update(Ash.Changeset.for_update(record, :complete_direct, params), ash_opts)
       _ -> {:ok, record}
     end
   end
@@ -130,10 +132,11 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
 
   defp next_candidates(step) do
     case step do
-      :s1_create -> [:s2_approve, :s3_reject]
+      :s1_create -> [:s2_approve, :s3_reject, :s5_complete_direct]
       :s2_approve -> [:s4_complete]
       :s3_reject -> [:s4_complete]
-      :s4_complete -> []
+      :s4_complete -> [:s5_complete_direct]
+      :s5_complete_direct -> []
       _ -> []
     end
   end
@@ -144,6 +147,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
       :s2_approve -> []
       :s3_reject -> []
       :s4_complete -> []
+      :s5_complete_direct -> []
       _ -> []
     end
   end
@@ -154,6 +158,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
       :s2_approve -> nil
       :s3_reject -> nil
       :s4_complete -> nil
+      :s5_complete_direct -> nil
       _ -> nil
     end
   end
@@ -164,6 +169,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
       :s2_approve -> false
       :s3_reject -> false
       :s4_complete -> false
+      :s5_complete_direct -> false
       _ -> false
     end
   end
@@ -174,6 +180,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
       :s2_approve -> %{max_attempts: 1, backoff_ms: 0}
       :s3_reject -> %{max_attempts: 1, backoff_ms: 0}
       :s4_complete -> %{max_attempts: 1, backoff_ms: 0}
+      :s5_complete_direct -> %{max_attempts: 1, backoff_ms: 0}
       _ -> %{max_attempts: 1, backoff_ms: 0}
     end
   end
@@ -184,6 +191,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelChangeOrder.ChangeOrderLifecycleWork
       :s2_approve -> nil
       :s3_reject -> nil
       :s4_complete -> nil
+      :s5_complete_direct -> nil
       _ -> nil
     end
   end

--- a/travel/lib/unibo_ex_poc/travel/workflows/travel_refund_order_refund_order_lifecycle.ex
+++ b/travel/lib/unibo_ex_poc/travel/workflows/travel_refund_order_refund_order_lifecycle.ex
@@ -7,11 +7,11 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
   alias UniboExPoc.Travel.TravelRefundOrder
 
   def steps do
-    [:s1_create, :s2_approve, :s3_reject, :s4_refund]
+    [:s1_create, :s2_approve, :s3_reject, :s4_refund, :s5_refund_direct]
   end
 
   @workflow_semantics_json ~S"""
-{"steps":[{"idempotency_key":null,"next":["approve","reject"],"next_step_ids":["s2_approve","s3_reject"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"create","step_id":"s1_create"},{"idempotency_key":null,"next":["refund"],"next_step_ids":["s4_refund"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"approve","step_id":"s2_approve"},{"idempotency_key":null,"next":["refund"],"next_step_ids":["s4_refund"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"reject","step_id":"s3_reject"},{"idempotency_key":null,"next":[],"next_step_ids":[],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"refund","step_id":"s4_refund"}],"workflow":"refund_order_lifecycle"}
+{"steps":[{"idempotency_key":null,"next":["approve","reject","refund_direct"],"next_step_ids":["s2_approve","s3_reject","s5_refund_direct"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"create","step_id":"s1_create"},{"idempotency_key":null,"next":["refund"],"next_step_ids":["s4_refund"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"approve","step_id":"s2_approve"},{"idempotency_key":null,"next":["refund"],"next_step_ids":["s4_refund"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"reject","step_id":"s3_reject"},{"idempotency_key":null,"next":["refund_direct"],"next_step_ids":["s5_refund_direct"],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"refund","step_id":"s4_refund"},{"idempotency_key":null,"next":[],"next_step_ids":[],"on_error":[],"on_error_step_ids":[],"retry":{"backoff_ms":0,"max_attempts":1},"step":"refund_direct","step_id":"s5_refund_direct"}],"workflow":"refund_order_lifecycle"}
 """
   def workflow_semantics_json, do: String.trim(@workflow_semantics_json)
 
@@ -106,6 +106,8 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
         Ash.update(Ash.Changeset.for_update(record, :reject, params), ash_opts)
       :s4_refund ->
         Ash.update(Ash.Changeset.for_update(record, :refund, params), ash_opts)
+      :s5_refund_direct ->
+        Ash.update(Ash.Changeset.for_update(record, :refund_direct, params), ash_opts)
       _ -> {:ok, record}
     end
   end
@@ -130,10 +132,11 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
 
   defp next_candidates(step) do
     case step do
-      :s1_create -> [:s2_approve, :s3_reject]
+      :s1_create -> [:s2_approve, :s3_reject, :s5_refund_direct]
       :s2_approve -> [:s4_refund]
       :s3_reject -> [:s4_refund]
-      :s4_refund -> []
+      :s4_refund -> [:s5_refund_direct]
+      :s5_refund_direct -> []
       _ -> []
     end
   end
@@ -144,6 +147,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
       :s2_approve -> []
       :s3_reject -> []
       :s4_refund -> []
+      :s5_refund_direct -> []
       _ -> []
     end
   end
@@ -154,6 +158,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
       :s2_approve -> nil
       :s3_reject -> nil
       :s4_refund -> nil
+      :s5_refund_direct -> nil
       _ -> nil
     end
   end
@@ -164,6 +169,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
       :s2_approve -> false
       :s3_reject -> false
       :s4_refund -> false
+      :s5_refund_direct -> false
       _ -> false
     end
   end
@@ -174,6 +180,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
       :s2_approve -> %{max_attempts: 1, backoff_ms: 0}
       :s3_reject -> %{max_attempts: 1, backoff_ms: 0}
       :s4_refund -> %{max_attempts: 1, backoff_ms: 0}
+      :s5_refund_direct -> %{max_attempts: 1, backoff_ms: 0}
       _ -> %{max_attempts: 1, backoff_ms: 0}
     end
   end
@@ -184,6 +191,7 @@ defmodule UniboExPoc.Travel.Workflows.TravelRefundOrder.RefundOrderLifecycleWork
       :s2_approve -> nil
       :s3_reject -> nil
       :s4_refund -> nil
+      :s5_refund_direct -> nil
       _ -> nil
     end
   end

--- a/travel/models/travel.ubo.yaml
+++ b/travel/models/travel.ubo.yaml
@@ -2191,6 +2191,12 @@ entities:
         constraints:
           values: ["pending", "approved", "completed", "rejected"]
         default: "pending"
+      - name: approval_mode
+        type: enum
+        constraints:
+          values: ["none", "self", "oa"]
+        default: "self"
+        description: 审批模式快照；none 表示跳过审批，self/oa 表示进入审批流
       - name: inserted_at
         type: datetime
         generated: true
@@ -2211,7 +2217,7 @@ entities:
       - name: create
         type: create
         primary: true
-        accept: [original_order_id, change_reason, price_difference, change_fee, new_offer_id]
+        accept: [original_order_id, change_reason, price_difference, change_fee, new_offer_id, approval_mode]
       - name: read
         type: read
         primary: true
@@ -2222,6 +2228,9 @@ entities:
         type: update
         accept: []
       - name: complete
+        type: update
+        accept: []
+      - name: complete_direct
         type: update
         accept: []
     validations:
@@ -2238,6 +2247,16 @@ entities:
         params: {values: ["approved"]}
         on: [complete]
         message: 只有 approved 改签单可以完成
+      - rule: one_of
+        field: approval_mode
+        params: {values: ["none"]}
+        on: [complete_direct]
+        message: 只有关闭审批的改签单可以直接完成
+      - rule: one_of
+        field: status
+        params: {values: ["pending"]}
+        on: [complete_direct]
+        message: 关闭审批时，pending 改签单可直接完成
     changes:
       - effect: set_attribute
         field: status
@@ -2252,12 +2271,16 @@ entities:
         value: "completed"
         on: [complete]
       - effect: set_attribute
+        field: status
+        value: "completed"
+        on: [complete_direct]
+      - effect: set_attribute
         field: id
         expr:
           op: ref
           args:
             - id
-        on: [create, approve, reject, complete]
+        on: [create, approve, reject, complete, complete_direct]
         description: AUTO_WRITE_ANCHOR
     events:
       - on: approve
@@ -2266,21 +2289,26 @@ entities:
         topic: travel.change_order.rejected
       - on: complete
         topic: travel.change_order.completed
+      - on: complete_direct
+        topic: travel.change_order.completed
     scenarios:
       - "create 创建改签单 -> approve 审批通过 -> complete 改签完成"
       - "create 创建改签单 -> reject 审批拒绝"
+      - "create 创建改签单（approval_mode=none）-> complete_direct 直接完成"
     workflows:
       - name: change_order_lifecycle
-        description: 改签单生命周期：pending → approved → completed，pending → rejected
+        description: 改签单生命周期：审批开启时 pending → approved → completed / rejected；审批关闭时 pending → completed
         steps:
           - action: create
-            next: [approve, reject]
+            next: [approve, reject, complete_direct]
           - action: approve
             trigger_event: travel.change_order.approved
             next: [complete]
           - action: reject
             trigger_event: travel.change_order.rejected
           - action: complete
+            trigger_event: travel.change_order.completed
+          - action: complete_direct
             trigger_event: travel.change_order.completed
     determine_actions:
       - name: notify_order_change_approved
@@ -2296,6 +2324,8 @@ entities:
         description: TravelChangeOrder 通过 original_order_id 关联原订单，new_offer_id 为字符串引用，不做跨实体外键
       - id: TRAVEL-CHANGE-ORDER-02
         description: 同一原订单在同一 status 下唯一，防止重复改签请求
+      - id: TRAVEL-CHANGE-ORDER-03
+        description: approval_mode=none 时跳过审批，允许改签单从 pending 直接完成
 
   - name: TravelRefundOrder
     description: 退票/退订单，记录针对已有 TravelOrder 的退票请求、手续费与退款状态
@@ -2319,6 +2349,12 @@ entities:
         constraints:
           values: ["pending", "approved", "refunded", "rejected"]
         default: "pending"
+      - name: approval_mode
+        type: enum
+        constraints:
+          values: ["none", "self", "oa"]
+        default: "self"
+        description: 审批模式快照；none 表示跳过审批，self/oa 表示进入审批流
       - name: inserted_at
         type: datetime
         generated: true
@@ -2339,7 +2375,7 @@ entities:
       - name: create
         type: create
         primary: true
-        accept: [original_order_id, refund_reason, refund_fee, refund_amount]
+        accept: [original_order_id, refund_reason, refund_fee, refund_amount, approval_mode]
       - name: read
         type: read
         primary: true
@@ -2350,6 +2386,9 @@ entities:
         type: update
         accept: []
       - name: refund
+        type: update
+        accept: []
+      - name: refund_direct
         type: update
         accept: []
     validations:
@@ -2366,6 +2405,16 @@ entities:
         params: {values: ["approved"]}
         on: [refund]
         message: 只有 approved 退票单可以执行退款
+      - rule: one_of
+        field: approval_mode
+        params: {values: ["none"]}
+        on: [refund_direct]
+        message: 只有关闭审批的退票单可以直接退款
+      - rule: one_of
+        field: status
+        params: {values: ["pending"]}
+        on: [refund_direct]
+        message: 关闭审批时，pending 退票单可直接退款
     changes:
       - effect: set_attribute
         field: status
@@ -2380,12 +2429,16 @@ entities:
         value: "refunded"
         on: [refund]
       - effect: set_attribute
+        field: status
+        value: "refunded"
+        on: [refund_direct]
+      - effect: set_attribute
         field: id
         expr:
           op: ref
           args:
             - id
-        on: [create, approve, reject, refund]
+        on: [create, approve, reject, refund, refund_direct]
         description: AUTO_WRITE_ANCHOR
     events:
       - on: approve
@@ -2394,21 +2447,26 @@ entities:
         topic: travel.refund_order.rejected
       - on: refund
         topic: travel.refund_order.refunded
+      - on: refund_direct
+        topic: travel.refund_order.refunded
     scenarios:
       - "create 创建退票单 -> approve 审批通过 -> refund 退款完成"
       - "create 创建退票单 -> reject 审批拒绝"
+      - "create 创建退票单（approval_mode=none）-> refund_direct 直接退款"
     workflows:
       - name: refund_order_lifecycle
-        description: 退票单生命周期：pending → approved → refunded，pending → rejected
+        description: 退票单生命周期：审批开启时 pending → approved → refunded / rejected；审批关闭时 pending → refunded
         steps:
           - action: create
-            next: [approve, reject]
+            next: [approve, reject, refund_direct]
           - action: approve
             trigger_event: travel.refund_order.approved
             next: [refund]
           - action: reject
             trigger_event: travel.refund_order.rejected
           - action: refund
+            trigger_event: travel.refund_order.refunded
+          - action: refund_direct
             trigger_event: travel.refund_order.refunded
     determine_actions:
       - name: notify_order_refund_approved
@@ -2424,6 +2482,8 @@ entities:
         description: TravelRefundOrder 通过 original_order_id 关联原订单，实际退款动作可由 Payment 域处理
       - id: TRAVEL-REFUND-ORDER-02
         description: 同一原订单在同一 status 下唯一，防止重复退票请求
+      - id: TRAVEL-REFUND-ORDER-03
+        description: approval_mode=none 时跳过审批，允许退票单从 pending 直接退款
 
   - name: TravelPolicy
     description: 差旅标准政策，定义不同企业、职级、城市等级下的差旅费用上限与超标策略
@@ -2467,6 +2527,12 @@ entities:
           values: ["block", "require_reason", "require_approval", "personal_pay"]
         required: true
         description: 超标处理策略
+      - name: approval_mode
+        type: enum
+        constraints:
+          values: ["none", "self", "oa"]
+        default: "self"
+        description: 审批模式；none 表示关闭审批，self/oa 表示进入对应审批流
       - name: personal_pay_ratio
         type: integer
         description: 个人支付比例 0-100
@@ -2490,14 +2556,14 @@ entities:
       - name: create
         type: create
         primary: true
-        accept: [policy_name, product_type, employee_level, city_tier, season, max_amount, cabin_class_limit, hotel_star_limit, exceed_strategy, personal_pay_ratio, enterprise_id]
+        accept: [policy_name, product_type, employee_level, city_tier, season, max_amount, cabin_class_limit, hotel_star_limit, exceed_strategy, approval_mode, personal_pay_ratio, enterprise_id]
       - name: read
         type: read
         primary: true
       - name: update
         type: update
         primary: true
-        accept: [policy_name, season, max_amount, cabin_class_limit, hotel_star_limit, exceed_strategy, personal_pay_ratio]
+        accept: [policy_name, season, max_amount, cabin_class_limit, hotel_star_limit, exceed_strategy, approval_mode, personal_pay_ratio]
       - name: activate
         type: update
         accept: []
@@ -2574,6 +2640,8 @@ entities:
         description: exceed_strategy 为四值枚举（block/require_reason/require_approval/personal_pay），决定超标时的处理方式
       - id: TRAVEL-POLICY-03
         description: enterprise_id 为字符串标识，不做跨域外键，由调用方传入
+      - id: TRAVEL-POLICY-04
+        description: approval_mode 控制 require_approval 是否真正进入审批；approval_mode=none 时不创建审批请求
 
   - name: TravelPolicyCheck
     description: 差标校验记录，记录订单下单时针对差旅政策的校验结果、超标金额与处理策略
@@ -2613,6 +2681,12 @@ entities:
       - name: approval_request_id
         type: string
         description: 审批请求ID（不做跨域外键）
+      - name: approval_mode
+        type: enum
+        constraints:
+          values: ["none", "self", "oa"]
+        default: "self"
+        description: 命中政策时的审批模式快照
       - name: inserted_at
         type: datetime
         generated: true
@@ -2639,7 +2713,7 @@ entities:
       - name: create
         type: create
         primary: true
-        accept: [order_id, policy_id, check_result, policy_amount, actual_amount, exceed_amount, exceed_ratio, exceed_strategy, exceed_reason, personal_pay_amount, approval_request_id]
+        accept: [order_id, policy_id, check_result, policy_amount, actual_amount, exceed_amount, exceed_ratio, exceed_strategy, exceed_reason, personal_pay_amount, approval_request_id, approval_mode]
       - name: read
         type: read
         primary: true
@@ -2667,3 +2741,5 @@ entities:
         description: 每个 TravelOrder 最多关联一条 TravelPolicyCheck 记录
       - id: TRAVEL-POLICY-CHECK-02
         description: approval_request_id 为字符串标识，不做跨域外键，由审批系统回填
+      - id: TRAVEL-POLICY-CHECK-03
+        description: approval_mode 记录命中政策时的审批模式；approval_mode=none 时即使 require_approval 也不进入审批流

--- a/travel/pages/admin/enterprise_settings.dsl
+++ b/travel/pages/admin/enterprise_settings.dsl
@@ -40,7 +40,7 @@
         CONTENT: "审批模式"
       [SELECT: approval_mode]
         ATTR: Name("approval_mode"), Label("审批模式"), Change("approval_mode_change")
-        CONTENT: "自建审批:self,OA集成:oa"
+        CONTENT: "关闭审批:none,自建审批:self,OA集成:oa"
       [IF: approval_mode == "oa"]
         [ALERT: oa_integration_alert]
           ATTR: Variant("info")

--- a/travel/pages/user/policy_check_detail.dsl
+++ b/travel/pages/user/policy_check_detail.dsl
@@ -108,7 +108,7 @@
   # 审批链时间线（超标且策略为需审批时显示）
   [SECTION: approval_timeline_section]
     [IF: check.check_result == "exceeded"]
-      [IF: check.exceed_strategy == "require_approval"]
+      [IF: check.exceed_strategy == "require_approval" && check.approval_mode != "none"]
       [CARD: timeline_card]
         [CARD_HEADER: timeline_card_header]
           [TEXT: timeline_title]

--- a/travel/priv/repo/migrations/20260317161000_add_approval_mode_to_travel_tables.exs
+++ b/travel/priv/repo/migrations/20260317161000_add_approval_mode_to_travel_tables.exs
@@ -1,0 +1,39 @@
+defmodule UniboExPoc.Repo.Migrations.AddApprovalModeToTravelTables do
+  use Ecto.Migration
+
+  def up do
+    alter table(:travel_policies) do
+      add :approval_mode, :text, default: "self"
+    end
+
+    alter table(:travel_policy_checks) do
+      add :approval_mode, :text
+    end
+
+    alter table(:travel_change_orders) do
+      add :approval_mode, :text, default: "self"
+    end
+
+    alter table(:travel_refund_orders) do
+      add :approval_mode, :text, default: "self"
+    end
+  end
+
+  def down do
+    alter table(:travel_refund_orders) do
+      remove :approval_mode
+    end
+
+    alter table(:travel_change_orders) do
+      remove :approval_mode
+    end
+
+    alter table(:travel_policy_checks) do
+      remove :approval_mode
+    end
+
+    alter table(:travel_policies) do
+      remove :approval_mode
+    end
+  end
+end

--- a/travel/test/unibo_ex_poc/travel/approval_mode_flow_test.exs
+++ b/travel/test/unibo_ex_poc/travel/approval_mode_flow_test.exs
@@ -1,0 +1,100 @@
+defmodule UniboExPoc.Travel.ApprovalModeFlowTest do
+  use ExUnit.Case, async: false
+
+  alias UniboExPoc.Travel.{TravelChangeOrder, TravelOrder, TravelRefundOrder}
+  alias Ecto.Adapters.SQL
+
+  setup do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(UniboExPoc.Repo, shared: false)
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    :ok
+  end
+
+  test "approval_mode none 时改签单可直接完成" do
+    order = create_order!("CHANGE")
+
+    change_order =
+      TravelChangeOrder
+      |> Ash.Changeset.for_create(:create, %{
+        original_order_id: order.id,
+        change_reason: "航班变更",
+        price_difference: "120",
+        change_fee: "50",
+        new_offer_id: "offer-change-1",
+        approval_mode: :none
+      })
+      |> Ash.create!(tenant: order.tenant_id)
+
+    assert change_order.status == :pending
+    assert change_order.approval_mode == :none
+
+    completed =
+      change_order
+      |> Ash.Changeset.for_update(:complete_direct, %{})
+      |> Ash.update!(tenant: order.tenant_id)
+
+    assert completed.status == :completed
+  end
+
+  test "approval_mode none 时退票单可直接退款" do
+    order = create_order!("REFUND")
+
+    refund_order =
+      TravelRefundOrder
+      |> Ash.Changeset.for_create(:create, %{
+        original_order_id: order.id,
+        refund_reason: "行程取消",
+        refund_fee: "20",
+        refund_amount: "300",
+        approval_mode: :none
+      })
+      |> Ash.create!(tenant: order.tenant_id)
+
+    assert refund_order.status == :pending
+    assert refund_order.approval_mode == :none
+
+    refunded =
+      refund_order
+      |> Ash.Changeset.for_update(:refund_direct, %{})
+      |> Ash.update!(tenant: order.tenant_id)
+
+    assert refunded.status == :refunded
+  end
+
+  defp create_order!(suffix) do
+    id = Ecto.UUID.generate()
+    tenant_id = Ecto.UUID.generate()
+    now = DateTime.utc_now()
+
+    SQL.query!(
+      UniboExPoc.Repo,
+      """
+      insert into travel_orders (
+        id, tenant_id, order_no, product_type, contact_name, contact_phone,
+        traveler_count, total_amount, points_to_use, points_deduction_amount,
+        currency, status, change_status, waitlist_status, inserted_at, updated_at
+      ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+      """,
+      [
+        Ecto.UUID.dump!(id),
+        Ecto.UUID.dump!(tenant_id),
+        "TEST-#{suffix}-#{System.unique_integer([:positive])}",
+        "flight",
+        "测试联系人",
+        "13800000000",
+        1,
+        Decimal.new("1000"),
+        0,
+        Decimal.new("0"),
+        "CNY",
+        "draft",
+        "none",
+        "none",
+        now,
+        now
+      ]
+    )
+
+    %TravelOrder{id: id, tenant_id: tenant_id}
+  end
+end

--- a/travel/test/unibo_ex_poc/travel/policy_engine_test.exs
+++ b/travel/test/unibo_ex_poc/travel/policy_engine_test.exs
@@ -31,6 +31,7 @@ defmodule UniboExPoc.Travel.PolicyEngineTest do
       assert result.exceed_amount == 500
       assert result.exceed_ratio == "50.0%"
       assert result.exceed_strategy == "require_approval"
+      assert result.approval_mode == "self"
     end
 
     test "personal_pay 策略计算个人支付金额" do
@@ -79,6 +80,15 @@ defmodule UniboExPoc.Travel.PolicyEngineTest do
       assert {:ok, :require_approval, ^check} = PolicyEngine.apply_strategy(check)
     end
 
+    test "超标 + require_approval + approval_mode none → proceed" do
+      assert {:ok, :proceed} =
+               PolicyEngine.apply_strategy(%{
+                 check_result: :exceeded,
+                 exceed_strategy: "require_approval",
+                 approval_mode: "none"
+               })
+    end
+
     test "超标 + personal_pay → ok personal_pay with amount" do
       check = %{
         check_result: :exceeded,
@@ -102,6 +112,7 @@ defmodule UniboExPoc.Travel.PolicyEngineTest do
       cabin_class_limit: "经济舱",
       hotel_star_limit: nil,
       exceed_strategy: :require_approval,
+      approval_mode: :self,
       personal_pay_ratio: nil,
       is_active: true,
       enterprise_id: nil


### PR DESCRIPTION
## Summary
- 为 TravelPolicy / TravelPolicyCheck / TravelChangeOrder / TravelRefundOrder 增加 approval_mode
- 为改签单和退票单增加关闭审批时的直达动作与最小前端显隐调整
- 补充 approval_mode 迁移、policy engine 行为与审批关闭流测试

## Test plan
- MIX_ENV=test mix test test/unibo_ex_poc/travel/policy_engine_test.exs test/unibo_ex_poc/travel/approval_mode_flow_test.exs
- MIX_ENV=test mix test test/bdd_generated/TRAVEL_TRAVEL_POLICY_generated_test.exs test/bdd_generated/TRAVEL_TRAVEL_POLICY_CHECK_generated_test.exs test/bdd_generated/TRAVEL_TRAVEL_CHANGE_ORDER_generated_test.exs test/bdd_generated/TRAVEL_TRAVEL_REFUND_ORDER_generated_test.exs

Closes #117
