### PR TITLE
fix: 添加 PubSub endpoint 修复 events notifier BDD failures

### DIFF
--- a/hospital_scheduling/lib/hospital_scheduling/pub_sub.ex
+++ b/hospital_scheduling/lib/hospital_scheduling/pub_sub.ex
@@ -1,0 +1,9 @@
+defmodule HospitalScheduling.PubSub do
+  @moduledoc """
+  PubSub 封装模块，供 Ash.Notifier.PubSub 使用。
+  """
+
+  def broadcast(topic, event, notification) do
+    Phoenix.PubSub.broadcast(__MODULE__, topic, {event, notification})
+  end
+end


### PR DESCRIPTION
## Summary
- 添加 `HospitalScheduling.PubSub` 模块，包含 `broadcast/3` 函数
- Ash.Notifier.PubSub 需要一个实际的模块（带 `broadcast/3`），而非仅 `application.ex` 中的进程注册名
- 修复 18 个 BDD 测试失败（从 19 failures 降至 1，剩余 1 个是 AshArchival 的 pre-existing issue）

Closes #121

## Test plan
- [x] `MIX_ENV=test mix test test/bdd_generated/` — 180 tests, 1 failure（pre-existing，与 PubSub 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)