### PR TITLE
fix: 移除跨域依赖实体的 policies 和 authorizers

### DIFF
--- a/travel/lib/unibo_ex_poc/accounting/journal_entry.ex
+++ b/travel/lib/unibo_ex_poc/accounting/journal_entry.ex
@@ -14,7 +14,6 @@ defmodule UniboExPoc.Accounting.JournalEntry do
     domain: UniboExPoc.Accounting,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [UniboExPoc.Accounting.JournalEntry.Notifier]
 
   resource do
@@ -255,24 +254,6 @@ reversed: 仅冲销分录匹配
 
   identities do
     identity :unique_entry_number_when_posted, [:entry_number, :journal_id]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:created_by)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:created_by)
-    end
-    policy action_type(:create) do
-      forbid_unless relates_to_actor_via(:created_by)
-      authorize_if expr(^actor(:role) == :admin)
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/accounting/payment.ex
+++ b/travel/lib/unibo_ex_poc/accounting/payment.ex
@@ -13,7 +13,6 @@ defmodule UniboExPoc.Accounting.Payment do
     domain: UniboExPoc.Accounting,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [UniboExPoc.Accounting.Payment.Notifier]
 
   resource do
@@ -207,24 +206,6 @@ defmodule UniboExPoc.Accounting.Payment do
 
   identities do
     identity :unique_payment_number, [:payment_number]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:created_by)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:created_by)
-    end
-    policy action_type(:create) do
-      forbid_unless relates_to_actor_via(:created_by)
-      authorize_if expr(^actor(:role) == :admin)
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/delivery/shipment.ex
+++ b/travel/lib/unibo_ex_poc/delivery/shipment.ex
@@ -23,7 +23,6 @@ defmodule UniboExPoc.Delivery.Shipment do
     domain: UniboExPoc.Delivery,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource, AshPaperTrail.Resource, AshArchival.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [Ash.Notifier.PubSub]
 
   resource do
@@ -284,24 +283,6 @@ defmodule UniboExPoc.Delivery.Shipment do
 
   archive do
     archive_related [:shipment_items, :shipment_packages, :route_segments, :status_history]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:create) do
-      forbid_unless relates_to_actor_via(:company_party)
-      authorize_if expr(^actor(:role) in [:logistics_manager, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 

--- a/travel/lib/unibo_ex_poc/payment/payment.ex
+++ b/travel/lib/unibo_ex_poc/payment/payment.ex
@@ -27,7 +27,6 @@ defmodule UniboExPoc.Payment.Payment do
     domain: UniboExPoc.Payment,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource, AshPaperTrail.Resource, AshArchival.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [Ash.Notifier.PubSub]
 
   resource do
@@ -297,24 +296,6 @@ defmodule UniboExPoc.Payment.Payment do
 
   archive do
     archive_related [:applications, :refunds]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:create) do
-      forbid_unless relates_to_actor_via(:company_party)
-      authorize_if expr(^actor(:role) in [:finance_clerk, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 

--- a/travel/lib/unibo_ex_poc/payment/payment_method.ex
+++ b/travel/lib/unibo_ex_poc/payment/payment_method.ex
@@ -20,8 +20,7 @@ defmodule UniboExPoc.Payment.PaymentMethod do
     otp_app: :travel,
     domain: UniboExPoc.Payment,
     data_layer: AshPostgres.DataLayer,
-    extensions: [AshGraphql.Resource, AshPaperTrail.Resource, AshArchival.Resource],
-    authorizers: [Ash.Policy.Authorizer]
+    extensions: [AshGraphql.Resource, AshPaperTrail.Resource, AshArchival.Resource]
 
   resource do
     description "支付方式，对应用户/客户绑定的具体支付手段（信用卡、银行账户、礼品卡等）"
@@ -140,24 +139,6 @@ defmodule UniboExPoc.Payment.PaymentMethod do
 
   archive do
     archive_related [:payments, :gateway_responses]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:party)
-    end
-    policy action_type(:create) do
-      forbid_unless relates_to_actor_via(:party)
-      authorize_if expr(^actor(:role) in [:finance_clerk, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/purchasing/product_supplierinfo.ex
+++ b/travel/lib/unibo_ex_poc/purchasing/product_supplierinfo.ex
@@ -14,7 +14,6 @@ defmodule UniboExPoc.Purchasing.ProductSupplierinfo do
     domain: UniboExPoc.Purchasing,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource, AshPaperTrail.Resource, AshArchival.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [UniboExPoc.Purchasing.ProductSupplierinfo.Notifier]
 
   resource do
@@ -204,15 +203,6 @@ defmodule UniboExPoc.Purchasing.ProductSupplierinfo do
   end
 
   archive do
-  end
-
-  policies do
-    policy action_type(:create) do
-      authorize_if always()
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/purchasing/purchase_order.ex
+++ b/travel/lib/unibo_ex_poc/purchasing/purchase_order.ex
@@ -43,7 +43,6 @@ defmodule UniboExPoc.Purchasing.PurchaseOrder do
     domain: UniboExPoc.Purchasing,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource, AshPaperTrail.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [UniboExPoc.Purchasing.PurchaseOrder.Notifier]
 
   resource do
@@ -402,26 +401,6 @@ defmodule UniboExPoc.Purchasing.PurchaseOrder do
     sum :total_quantity, :order_lines, field: :quantity
     sum :total_received, :order_lines, field: :qty_received
     sum :total_invoiced, :order_lines, field: :qty_invoiced
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company)
-    end
-    policy action_type(:create) do
-      authorize_if expr(actor.role in [:buyer, :admin])
-    end
-    policy action(:button_approve) do
-      authorize_if expr(^actor(:role) == :purchase_manager or unknown_func())
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/purchasing/supplier.ex
+++ b/travel/lib/unibo_ex_poc/purchasing/supplier.ex
@@ -16,8 +16,7 @@ defmodule UniboExPoc.Purchasing.Supplier do
     otp_app: :travel,
     domain: UniboExPoc.Purchasing,
     data_layer: AshPostgres.DataLayer,
-    extensions: [AshGraphql.Resource, AshPaperTrail.Resource],
-    authorizers: [Ash.Policy.Authorizer]
+    extensions: [AshGraphql.Resource, AshPaperTrail.Resource]
 
   resource do
     description "供应商主数据（对应 OFBiz PartyGroup + PartyRole SUPPLIER）"
@@ -207,23 +206,6 @@ defmodule UniboExPoc.Purchasing.Supplier do
     change_tracking_mode :full_diff
     store_action_name? true
     ignore_attributes [:inserted_at, :updated_at]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:create) do
-      authorize_if expr(actor.role in [:buyer, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/sales/customer.ex
+++ b/travel/lib/unibo_ex_poc/sales/customer.ex
@@ -13,8 +13,7 @@ defmodule UniboExPoc.Sales.Customer do
     otp_app: :travel,
     domain: UniboExPoc.Sales,
     data_layer: AshPostgres.DataLayer,
-    extensions: [AshGraphql.Resource, AshPaperTrail.Resource],
-    authorizers: [Ash.Policy.Authorizer]
+    extensions: [AshGraphql.Resource, AshPaperTrail.Resource]
 
   resource do
     description "客户主数据（对应 OFBiz PartyGroup + PartyRole CUSTOMER）"
@@ -172,23 +171,6 @@ defmodule UniboExPoc.Sales.Customer do
     change_tracking_mode :full_diff
     store_action_name? true
     ignore_attributes [:inserted_at, :updated_at]
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:create) do
-      authorize_if expr(actor.role in [:sales_rep, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 end

--- a/travel/lib/unibo_ex_poc/sales/sales_order.ex
+++ b/travel/lib/unibo_ex_poc/sales/sales_order.ex
@@ -31,7 +31,6 @@ defmodule UniboExPoc.Sales.SalesOrder do
     domain: UniboExPoc.Sales,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshGraphql.Resource, AshPaperTrail.Resource],
-    authorizers: [Ash.Policy.Authorizer],
     notifiers: [Ash.Notifier.PubSub]
 
   resource do
@@ -315,23 +314,6 @@ defmodule UniboExPoc.Sales.SalesOrder do
   aggregates do
     count :total_items, :items
     sum :total_quantity, :items, field: :quantity
-  end
-
-  policies do
-    policy action_type(:read) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:update) do
-      authorize_if expr(^actor(:role) == :admin)
-      authorize_if relates_to_actor_via(:company_party)
-    end
-    policy action_type(:create) do
-      authorize_if expr(actor.role in [:sales_rep, :admin])
-    end
-    policy always() do
-      authorize_if always()
-    end
   end
 
 


### PR DESCRIPTION
## Summary

- 移除 Travel 项目中 10 个跨域依赖实体（sales/purchasing/payment/accounting/delivery）的 `Ash.Policy.Authorizer` 和 `policies do ... end` 块
- Travel 自有的 15 个实体本身无 policies，跨域实体的 policies 是从 OFBiz 域模型复制过来的冗余配置
- 共删除 183 行代码，消除 10 个不必要的 Authorizer

Closes #139

## Test plan

- [x] `mix compile` 编译通过
- [x] 测试结果与改动前一致（1243 tests, 756 failures — 所有失败均为预存的 BDD YAML 路径问题，非本次改动引入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)