### PR TITLE
fix: TravelOrder 补充 request_cancel 事件声明

### DIFF
--- a/travel/models/travel.ubo.yaml
+++ b/travel/models/travel.ubo.yaml
@@ -1693,6 +1693,8 @@ entities:
         topic: travel.order.waitlist_fulfilled
       - on: cancel_waitlist
         topic: travel.order.waitlist_cancelled
+      - on: request_cancel
+        topic: travel.order.cancel_requested
       - on: approve_cancel
         topic: travel.order.cancelled
       - on: confirm_change


### PR DESCRIPTION
## Summary
- TravelOrder 的 `request_cancel` action 缺少 events 声明，导致取消申请时不会发布事件
- 在 events 列表中补充 `on: request_cancel` / `topic: travel.order.cancel_requested`

Closes #147

## Test plan
- [x] unibo 编译器验证通过（0 error）
- [ ] 生成代码中确认 `publish :request_cancel, ["travel.order.cancel_requested"]` 存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)