### PR TITLE
fix: SchedulingPeriod.mark_adjusted 标记 public: false

### DIFF
--- a/hospital_scheduling/models/scheduling.ubo.yaml
+++ b/hospital_scheduling/models/scheduling.ubo.yaml
@@ -311,6 +311,7 @@ entities:
             value: generated
       - name: mark_adjusted
         type: update
+        public: false
         description: 人工调班后标记
         accept: []
         changes:


### PR DESCRIPTION
## Summary
- SchedulingPeriod 的 `mark_adjusted` action 添加 `public: false`，使其不暴露为公开 API
- 该 action 是内部状态迁移（generated → adjusted），仅由系统内部调用

Closes #148

## Test plan
- [x] `mix compile` 通过（无新增错误）
- [ ] 验证 GraphQL schema 中不再暴露 `markAdjusted` mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)