### PR TITLE
feat: DSL 枚举值改为 BIND 驱动

### DIFF
--- a/hospital_scheduling/pages/scheduling/admin/calendar_adjustment.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/calendar_adjustment.dsl
@@ -97,6 +97,7 @@
             [FLEX: vio_item]
               { Gap: 2, Align: "Center" }
               [BADGE: vio_severity]
+                BIND: Enum("severity")
                 CONTENT: "{{vio.severity|}}"
               [TEXT: vio_message]
                 ATTR: Variant("caption")

--- a/hospital_scheduling/pages/scheduling/admin/publish_preview.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/publish_preview.dsl
@@ -16,6 +16,7 @@
             CONTENT: "v{{version.version_no|}}"
           [BADGE: origin_badge]
             ATTR: Variant("secondary")
+            BIND: Enum("origin_type")
             CONTENT: "{{version.origin_type|}}"
       [BUTTON: back_btn]
         ATTR: Variant("secondary"), Click("navigate_back")

--- a/hospital_scheduling/pages/scheduling/admin/requirement_matrix.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/requirement_matrix.dsl
@@ -13,6 +13,7 @@
         [FLEX: subtitle_row]
           { Gap: 2 }
           [BADGE: state_badge]
+            BIND: Enum("state")
             CONTENT: "{{period.state|}}"
           [TEXT: date_range]
             ATTR: Variant("muted")

--- a/hospital_scheduling/pages/scheduling/admin/scheduling_constraint_list.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/scheduling_constraint_list.dsl
@@ -24,13 +24,13 @@
           { Gap: 4, Align: "Center" }
           [SELECT: filter_constraint_type]
             ATTR: Name("constraint_type"), Label("约束类型")
-            CONTENT: "全部:,硬约束:hard,软约束:soft"
+            BIND: Enum("constraint_type")
           [SELECT: filter_category]
             ATTR: Name("category"), Label("规则类别")
-            CONTENT: "全部:,夜班后休息:rest_after_night,最大连续天数:max_consecutive_days,请假尊重:respect_leave,技能要求:skill_requirement,月度工时上限:max_monthly_hours,带班覆盖:lead_coverage,夜班公平:fair_night_distribution,周末公平:fair_weekend_distribution,偏好尊重:respect_preference,连续夜班限制:limit_consecutive_nights,班次连续性:shift_continuity"
+            BIND: Enum("category")
           [SELECT: filter_enabled]
             ATTR: Name("enabled"), Label("状态")
-            CONTENT: "全部:,启用:true,停用:false"
+            BIND: Enum("enabled")
           [BUTTON: filter_submit]
             ATTR: Variant("secondary"), Click("filter_submit")
             CONTENT: "查询"
@@ -60,15 +60,18 @@
               CONTENT: "{{row.name|}}"
             [TABLE_CELL: td_type]
               [BADGE: type_badge]
+                BIND: Enum("constraint_type")
                 CONTENT: "{{row.constraint_type|}}"
             [TABLE_CELL: td_category]
               [BADGE: category_badge]
                 ATTR: Variant("secondary")
+                BIND: Enum("category")
                 CONTENT: "{{row.category|}}"
             [TABLE_CELL: td_weight]
               CONTENT: "{{row.weight|}}"
             [TABLE_CELL: td_enabled]
               [BADGE: enabled_badge]
+                BIND: Enum("enabled")
                 CONTENT: "{{row.enabled|}}"
             [TABLE_CELL: td_notes]
               CONTENT: "{{row.notes|}}"

--- a/hospital_scheduling/pages/scheduling/admin/scheduling_period_detail.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/scheduling_period_detail.dsl
@@ -23,9 +23,11 @@
           ATTR: Variant("title")
           CONTENT: "{{record.title|}}"
         [BADGE: state_badge]
+          BIND: Enum("state")
           CONTENT: "{{record.state|}}"
         [BADGE: mode_badge]
           ATTR: Variant("secondary")
+          BIND: Enum("generation_mode")
           CONTENT: "{{record.generation_mode|}}"
       [FLEX: actions_group]
         { Gap: 2 }
@@ -80,6 +82,7 @@
               ATTR: Variant("caption"), Color("muted")
               CONTENT: "最近求解"
             [BADGE: run_status_badge]
+              BIND: Enum("status", entity: "SolverRun")
               CONTENT: "{{record.last_solver_run.status|}}"
 
   [SECTION: nav_section]
@@ -145,10 +148,12 @@
                   CONTENT: "v{{ver.version_no|}}"
                 [TABLE_CELL: td_ver_status]
                   [BADGE: ver_status_badge]
+                    BIND: Enum("status", entity: "ScheduleVersion")
                     CONTENT: "{{ver.status|}}"
                 [TABLE_CELL: td_ver_origin]
                   [BADGE: ver_origin_badge]
                     ATTR: Variant("secondary")
+                    BIND: Enum("origin_type")
                     CONTENT: "{{ver.origin_type|}}"
                 [TABLE_CELL: td_ver_summary]
                   CONTENT: "{{ver.change_summary|}}"
@@ -182,6 +187,7 @@
                   CONTENT: "{{run.engine_type|}}"
                 [TABLE_CELL: td_run_status]
                   [BADGE: run_status]
+                    BIND: Enum("status", entity: "SolverRun")
                     CONTENT: "{{run.status|}}"
                 [TABLE_CELL: td_run_score]
                   CONTENT: "{{run.score|}}"

--- a/hospital_scheduling/pages/scheduling/admin/scheduling_period_list.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/scheduling_period_list.dsl
@@ -19,7 +19,7 @@
           { Gap: 4, Align: "Center" }
           [SELECT: filter_state]
             ATTR: Name("state"), Label("状态")
-            CONTENT: "全部:,草稿:draft,生成中:generating,已生成:generated,已调整:adjusted,已发布:published"
+            BIND: Enum("state")
           [SELECT: filter_department]
             ATTR: Name("department_id"), Label("科室")
           [INPUT: filter_start_date]
@@ -59,9 +59,11 @@
               CONTENT: "{{row.end_date|}}"
             [TABLE_CELL: td_state]
               [BADGE: state_badge]
+                BIND: Enum("state")
                 CONTENT: "{{row.state|}}"
             [TABLE_CELL: td_generation_mode]
               [BADGE: mode_badge]
+                BIND: Enum("generation_mode")
                 CONTENT: "{{row.generation_mode|}}"
             [TABLE_CELL: td_actions]
               [FLEX: row_actions]

--- a/hospital_scheduling/pages/scheduling/admin/solver_result.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/solver_result.dsl
@@ -13,6 +13,7 @@
         [FLEX: subtitle_row]
           { Gap: 2 }
           [BADGE: run_status_badge]
+            BIND: Enum("status", entity: "SolverRun")
             CONTENT: "{{run.status|}}"
           [TEXT: engine_info]
             ATTR: Variant("muted")
@@ -91,6 +92,7 @@
               [TABLE_ROW: vio_row]
                 [TABLE_CELL: td_severity]
                   [BADGE: severity_badge]
+                    BIND: Enum("severity")
                     CONTENT: "{{vio.severity|}}"
                 [TABLE_CELL: td_rule]
                   CONTENT: "{{vio.rule_code|}}"


### PR DESCRIPTION
## Summary
- 将 Scheduling DSL 页面中硬写的枚举选项值（SELECT 筛选器、BADGE 展示）全部替换为 `BIND: Enum("field")` 声明
- 涉及 7 个 DSL 页面、20 处 BIND 声明（3 个 SELECT 筛选器 + 17 个 BADGE 展示）
- 枚举值由运行时从 Ash 资源 schema 的 `one_of` 约束动态解析，不再硬写在 DSL 中

Closes #146

## Test plan
- [ ] 排班周期列表页：状态筛选下拉正常加载枚举选项
- [ ] 约束配置列表页：约束类型/规则类别/启用状态筛选正常
- [ ] 各页面 BADGE 展示枚举值中文标签正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)