### PR TITLE
fix: 修复 Travel 6 个测试文件引用未定义模块

### DIFF
--- a/travel/test/unibo_ex_poc/travel/caller_context_test.exs
+++ b/travel/test/unibo_ex_poc/travel/caller_context_test.exs
@@ -1,7 +1,7 @@
 defmodule UniboExPoc.Travel.CallerContextTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TravelHost.CallerContext
+  alias Travel.TravelHost.CallerContext
 
   test "可以从宿主 header 风格字段归一化 CallerContext" do
     assert {:ok, context} =

--- a/travel/test/unibo_ex_poc/travel/eligibility_quote_test.exs
+++ b/travel/test/unibo_ex_poc/travel/eligibility_quote_test.exs
@@ -1,10 +1,10 @@
 defmodule UniboExPoc.Travel.EligibilityQuoteTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TravelHost.CallerContext
-  alias UniboExPoc.TravelHost.EligibilityOrQuote
-  alias UniboExPoc.TravelHost.HostConfig
-  alias UniboExPoc.TravelHost.PaymentExecution
+  alias Travel.TravelHost.CallerContext
+  alias Travel.TravelHost.EligibilityOrQuote
+  alias Travel.TravelHost.HostConfig
+  alias Travel.TravelHost.PaymentExecution
 
   test "宿主关闭 travel 时，quote 会直接拒绝" do
     {:ok, context} =

--- a/travel/test/unibo_ex_poc/travel/hotel_flow_test.exs
+++ b/travel/test/unibo_ex_poc/travel/hotel_flow_test.exs
@@ -1,11 +1,11 @@
 defmodule UniboExPoc.Travel.HotelFlowTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TestSupport.FakeShopTransport
-  alias UniboExPoc.TravelStack.HotelFlow
+  alias Travel.TestSupport.FakeShopTransport
+  alias Travel.TravelStack.HotelFlow
   alias UniboExPoc.Travel.TravelFulfillment
   alias UniboExPoc.Travel.TravelOrder
-  alias UniboExPoc.TravelHost.ShopBridgeClient
+  alias Travel.TravelHost.ShopBridgeClient
 
   test "HotelFlow 仅作为测试辅助时，hotel 闭环可通过 DefaultBridge 跑通" do
     input = %{

--- a/travel/test/unibo_ex_poc/travel/hotel_supplier_adapter_prep_test.exs
+++ b/travel/test/unibo_ex_poc/travel/hotel_supplier_adapter_prep_test.exs
@@ -1,8 +1,8 @@
 defmodule UniboExPoc.Travel.HotelSupplierAdapterPrepTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TravelStack.HotelFlow
-  alias UniboExPoc.TravelSupplier.HotelMockAdapter
+  alias Travel.TravelStack.HotelFlow
+  alias Travel.TravelSupplier.HotelMockAdapter
 
   test "成功场景：supplier book 返回 confirmed" do
     assert {:ok, result} =

--- a/travel/test/unibo_ex_poc/travel/http_transport_test.exs
+++ b/travel/test/unibo_ex_poc/travel/http_transport_test.exs
@@ -1,7 +1,7 @@
 defmodule UniboExPoc.Travel.HTTPTransportTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TravelHost.HTTPTransport
+  alias Travel.TravelHost.HTTPTransport
 
   test "request 会把操作映射到宿主 endpoint 并解析 JSON 响应" do
     payload = %{caller_context: %{user_id: "user-1"}}

--- a/travel/test/unibo_ex_poc/travel/shop_bridge_client_test.exs
+++ b/travel/test/unibo_ex_poc/travel/shop_bridge_client_test.exs
@@ -1,9 +1,9 @@
 defmodule UniboExPoc.Travel.ShopBridgeClientTest do
   use ExUnit.Case, async: true
 
-  alias UniboExPoc.TestSupport.FakeShopTransport
-  alias UniboExPoc.TravelHost.CallerContext
-  alias UniboExPoc.TravelHost.ShopBridgeClient
+  alias Travel.TestSupport.FakeShopTransport
+  alias Travel.TravelHost.CallerContext
+  alias Travel.TravelHost.ShopBridgeClient
 
   test "resolve_context 可以把宿主 bridge 返回映射成 CallerContext" do
     assert {:ok, context} =
@@ -109,7 +109,7 @@ defmodule UniboExPoc.Travel.ShopBridgeClientTest do
   end
 
   test "execute_payment 成功时会把 shop bridge 响应映射成 PaymentExecution" do
-    quote = %UniboExPoc.TravelHost.EligibilityOrQuote{
+    quote = %Travel.TravelHost.EligibilityOrQuote{
       allowed?: true,
       product_type: :hotel,
       travel_enabled: true,


### PR DESCRIPTION
## Summary

- 6 个 Travel 测试文件中的 alias 引用了 `UniboExPoc.TravelHost`/`TravelStack`/`TravelSupplier`/`TestSupport` 命名空间，但这些模块实际定义在 `test/support/travel_host_compat.ex` 中，使用的是 `Travel.*` 命名空间
- 将所有 15 处引用从 `UniboExPoc.*` 修正为 `Travel.*`，与 compat 模块定义对齐
- `mix compile` 验证通过，无新增 warning

## Test plan

- [x] `mix compile` 无未定义模块 warning
- [ ] `mix test test/unibo_ex_poc/travel/` 6 个测试文件通过

Closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)