### PR TITLE
fix: 补充 DSL 页面遗漏的 BIND 枚举声明

### DIFF
--- a/hospital_scheduling/pages/scheduling/admin/publish_preview.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/publish_preview.dsl
@@ -16,6 +16,7 @@
             CONTENT: "v{{version.version_no|}}"
           [BADGE: origin_badge]
             ATTR: Variant("secondary")
+            BIND: Enum("origin_type")
             CONTENT: "{{version.origin_type|}}"
       [BUTTON: back_btn]
         ATTR: Variant("secondary"), Click("navigate_back")

--- a/hospital_scheduling/pages/scheduling/admin/scheduling_constraint_list.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/scheduling_constraint_list.dsl
@@ -68,10 +68,12 @@
               CONTENT: "{{row.name|}}"
             [TABLE_CELL: td_type]
               [BADGE: type_badge]
+                BIND: Enum("constraint_type")
                 CONTENT: "{{row.constraint_type|}}"
             [TABLE_CELL: td_category]
               [BADGE: category_badge]
                 ATTR: Variant("secondary")
+                BIND: Enum("category")
                 CONTENT: "{{row.category|}}"
             [TABLE_CELL: td_weight]
               CONTENT: "{{row.weight|}}"

--- a/hospital_scheduling/pages/scheduling/admin/scheduling_period_list.dsl
+++ b/hospital_scheduling/pages/scheduling/admin/scheduling_period_list.dsl
@@ -59,9 +59,11 @@
               CONTENT: "{{row.end_date|}}"
             [TABLE_CELL: td_state]
               [BADGE: state_badge]
+                BIND: Enum("state")
                 CONTENT: "{{row.state|}}"
             [TABLE_CELL: td_generation_mode]
               [BADGE: mode_badge]
+                BIND: Enum("generation_mode")
                 CONTENT: "{{row.generation_mode|}}"
             [TABLE_CELL: td_actions]
               [FLEX: row_actions]


### PR DESCRIPTION
## Summary

- **publish_preview.dsl**: 补充 `origin_type` 的 BIND Enum 声明
- **scheduling_constraint_list.dsl**: 补充表格中 `constraint_type` 和 `category` 的 BIND Enum 声明
- **scheduling_period_list.dsl**: 补充表格中 `state` 和 `generation_mode` 的 BIND Enum 声明

此前的 #152 修复了 7 个 DSL 页面中的 BIND 语法错误（`entity:` 参数顺序、boolean 误用 Enum），但遗漏了上述 3 个页面的表格/Badge 中缺少 BIND 声明的问题。

Closes #146

## Test plan

- [x] 7 个 DSL 页面 `expand` 全部通过
- [x] `compile-frontend --seed scheduling` 全部通过（10/10 DSL, 10/10 expand, 7/7 HEEx）

🤖 Generated with [Claude Code](https://claude.com/claude-code)