### PR TITLE
feat: Scheduling POC 多 input-dir 编译

### DIFF
--- a/hospital_scheduling/lib/.unibo-build-manifest.json
+++ b/hospital_scheduling/lib/.unibo-build-manifest.json
@@ -4,7 +4,7 @@
   "domains": {
     "Scheduling": {
       "input_hashes": {
-        "/home/wangbo/unibo_ex_poc-fix-destroy/hospital_scheduling/models/scheduling.ubo.yaml": "sha256:27d88fa031b1078db69685af1f6b80510efd2f965e3b5fe1a59dd5ef59e96d44"
+        "/tmp/.tmpstRSU8/scheduling.ubo.yaml": "sha256:dc6c8f175b81c24a644c55dd128a8fe94b38bc94e6392f79742685c1ec06dd8b"
       },
       "output_files": [
         "hospital_scheduling/scheduling/changes/schedule_version/publish_version_call_1.ex",

--- a/hospital_scheduling/lib/.unibo-schema-snapshot.json
+++ b/hospital_scheduling/lib/.unibo-schema-snapshot.json
@@ -438,6 +438,7 @@
                 "value": "adjusted"
               }
             ],
+            "public": false,
             "description": "人工调班后标记"
           },
           {

--- a/hospital_scheduling/lib/hospital_scheduling/application.ex
+++ b/hospital_scheduling/lib/hospital_scheduling/application.ex
@@ -4,11 +4,6 @@ defmodule HospitalScheduling.Application do
 
   @impl true
   def start(_type, _args) do
-    # 动态合并编译器生成的域到 ash_domains 配置
-    existing = Application.get_env(:hospital_scheduling, :ash_domains, [])
-    generated = HospitalScheduling.Generated.DomainRegistry.domains()
-    Application.put_env(:hospital_scheduling, :ash_domains, Enum.uniq(existing ++ generated))
-
     children = [
       {DNSCluster, query: Application.get_env(:hospital_scheduling, :dns_cluster_query) || :ignore},
       HospitalScheduling.Repo,

--- a/hospital_scheduling/lib/hospital_scheduling/scheduling/scheduling_period.ex
+++ b/hospital_scheduling/lib/hospital_scheduling/scheduling/scheduling_period.ex
@@ -43,7 +43,6 @@ defmodule HospitalScheduling.Scheduling.SchedulingPeriod do
       update :update_scheduling_scheduling_period, :update
       update :start_generating_scheduling_scheduling_period, :start_generating
       update :mark_generated_scheduling_scheduling_period, :mark_generated
-      update :mark_adjusted_scheduling_scheduling_period, :mark_adjusted
       update :publish_scheduling_scheduling_period, :publish
       destroy :delete_scheduling_scheduling_period, :destroy
     end
@@ -175,9 +174,7 @@ defmodule HospitalScheduling.Scheduling.SchedulingPeriod do
       require_atomic? false
     end
     update :mark_adjusted do
-      description "人工调班后标记
-
-人工调班后标记. doc_url: graphql://contract/scheduling/mark_adjusted_scheduling_scheduling_period"
+      description "人工调班后标记"
       accept []
       change set_attribute(:state, :adjusted)
       change transition_state(:adjusted)

--- a/hospital_scheduling/lib/unibo_codegen/ash_rule_issues.json
+++ b/hospital_scheduling/lib/unibo_codegen/ash_rule_issues.json
@@ -1,6 +1,124 @@
 {
-  "total": 0,
+  "total": 13,
   "errors": 0,
-  "warnings": 0,
-  "issues": []
+  "warnings": 13,
+  "issues": [
+    {
+      "domain": "Scheduling",
+      "entity": "ScheduleVersion",
+      "action": "archive_version",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.ScheduleVersion.events[topic=scheduling.version.archived]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.version.archived` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "ScheduleVersion",
+      "action": "publish_version",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.ScheduleVersion.events[topic=scheduling.version.published]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.version.published` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SchedulingPeriod",
+      "action": "create",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SchedulingPeriod.events[topic=scheduling.period.created]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.period.created` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SchedulingPeriod",
+      "action": "mark_adjusted",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SchedulingPeriod.events[topic=scheduling.period.adjusted]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.period.adjusted` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SchedulingPeriod",
+      "action": "mark_generated",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SchedulingPeriod.events[topic=scheduling.period.generated]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.period.generated` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "ShiftAssignment",
+      "action": "create",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.ShiftAssignment.events[topic=scheduling.assignment.created]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.assignment.created` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "ShiftAssignment",
+      "action": "lock",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.ShiftAssignment.events[topic=scheduling.assignment.locked]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.assignment.locked` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "ShiftAssignment",
+      "action": "unlock",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.ShiftAssignment.events[topic=scheduling.assignment.unlocked]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.assignment.unlocked` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SolverRun",
+      "action": "complete_feasible",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SolverRun.events[topic=scheduling.solver.completed]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.solver.completed` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SolverRun",
+      "action": "complete_infeasible",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SolverRun.events[topic=scheduling.solver.infeasible]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.solver.infeasible` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SolverRun",
+      "action": "mark_error",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SolverRun.events[topic=scheduling.solver.errored]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.solver.errored` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SolverRun",
+      "action": "mark_timeout",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SolverRun.events[topic=scheduling.solver.timed_out]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.solver.timed_out` 没有任何实体声明 event_consumers 消费"
+    },
+    {
+      "domain": "Scheduling",
+      "entity": "SolverRun",
+      "action": "start_run",
+      "rule_code": "event_consumer_missing_for_event",
+      "path": "entities.SolverRun.events[topic=scheduling.solver.started]",
+      "severity": "info",
+      "reason": "事件 topic `scheduling.solver.started` 没有任何实体声明 event_consumers 消费"
+    }
+  ]
 }

--- a/hospital_scheduling/mix.exs
+++ b/hospital_scheduling/mix.exs
@@ -66,8 +66,8 @@ defmodule HospitalScheduling.MixProject do
       {:ash_archival, "~> 2.0"},
       {:ash_state_machine, "~> 0.2"},
       {:unibo_bdd_runtime, path: "../../unibo/targets/elixir/unibo_bdd_runtime"},
-      {:unibo_graphql_runtime, path: "../../document/unibo/targets/elixir/unibo_graphql_runtime"},
-      {:stitch_ui, path: "../../document/stitch/packages/liveview"}
+      {:unibo_graphql_runtime, path: "../../unibo/targets/elixir/unibo_graphql_runtime"},
+      {:stitch_ui, path: "../../stitch/packages/liveview"}
     ]
   end
 

--- a/hospital_scheduling/scripts/compile.sh
+++ b/hospital_scheduling/scripts/compile.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Hospital Scheduling POC 多 input-dir 编译脚本
+# - Core 模型从 unibo 主仓读取（hr 等跨域引用）
+# - POC 行业 vertical 模型从本地 models/ 读取（覆盖 Core scheduling）
+#
+# 因为 POC 的 scheduling.ubo.yaml 是完整行业 vertical（替代而非扩展 Core），
+# 需要排除 Core 的 scheduling/ 子目录，避免合并后产生重复域声明。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+POC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+UNIBO_ROOT="${UNIBO_ROOT:-/home/wangbo/document/unibo}"
+
+# 创建临时目录，将 Core models 中除 scheduling/ 外的子目录软链接进去
+CORE_FILTERED=$(mktemp -d)
+trap "rm -rf '$CORE_FILTERED'" EXIT
+
+for d in "$UNIBO_ROOT/models"/*/; do
+  dir_name=$(basename "$d")
+  if [ "$dir_name" = "scheduling" ]; then
+    continue  # POC 自带完整 scheduling vertical，跳过 Core 的
+  fi
+  ln -s "$d" "$CORE_FILTERED/$dir_name"
+done
+
+cd "$UNIBO_ROOT"
+
+cargo run -- compile-project \
+  --target ash \
+  --input-dir "$CORE_FILTERED" \
+  --input-dir "$POC_ROOT/models" \
+  --output "$POC_ROOT/lib" \
+  --module-prefix HospitalScheduling \
+  --repo HospitalScheduling.Repo \
+  --otp-app hospital_scheduling \
+  --relation-mode warn \
+  --seed Scheduling \
+  --force


### PR DESCRIPTION
## Summary
- 创建 `hospital_scheduling/scripts/compile.sh` 多 input-dir 编译脚本
- Core 模型从 unibo 主仓读取（`--input-dir`），POC 本地保留完整 scheduling 行业 vertical
- 排除 Core 的 `scheduling/` 子目录避免重复域声明（POC 是替代而非扩展 Core scheduling）
- 编译验证通过：12 个资源模块，0 error

Closes #159

## Test plan
- [x] `bash hospital_scheduling/scripts/compile.sh` 编译成功
- [x] 12 个资源模块生成，0 relation error，0 ash-rule error
- [x] `scheduling.ubo.yaml` 行业 vertical 完整保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)