### PR TITLE
fix: 填充 travel seed 和 scheduling period_detail mock

### DIFF
--- a/hospital_scheduling/priv/static/scheduling_pages/scheduling/scheduling_period_detail.expanded.mock.json
+++ b/hospital_scheduling/priv/static/scheduling_pages/scheduling/scheduling_period_detail.expanded.mock.json
@@ -1,67 +1,96 @@
 {
   "record": {
-    "title": "",
-    "state": "",
-    "generation_mode": "",
+    "title": "ICU 2026年3月第4周排班",
+    "state": "draft",
+    "generation_mode": "auto",
     "department": {
-      "name": ""
+      "name": "ICU"
     },
-    "start_date": "",
-    "end_date": "",
+    "start_date": "2026-03-23",
+    "end_date": "2026-03-29",
     "current_version": {
-      "version_no": ""
+      "version_no": "v1"
     },
     "last_solver_run": {
-      "status": ""
+      "status": "completed"
     },
     "schedule_versions": [
       {
-        "version_no": "",
-        "status": "",
-        "origin_type": "",
-        "change_summary": "",
-        "inserted_at": ""
+        "version_no": "v1",
+        "status": "draft",
+        "origin_type": "solver",
+        "change_summary": "求解器自动生成初始排班方案，覆盖 7 天 × 3 班次 × 10 名护士",
+        "inserted_at": "2026-03-22T10:00:00Z"
       },
       {
-        "version_no": "",
-        "status": "",
-        "origin_type": "",
-        "change_summary": "",
-        "inserted_at": ""
+        "version_no": "v2",
+        "status": "draft",
+        "origin_type": "manual",
+        "change_summary": "手动调整：周三大夜班张三换为李四（张三请假）",
+        "inserted_at": "2026-03-22T14:30:00Z"
       },
       {
-        "version_no": "",
-        "status": "",
-        "origin_type": "",
-        "change_summary": "",
-        "inserted_at": ""
+        "version_no": "v3",
+        "status": "pending_approval",
+        "origin_type": "manual",
+        "change_summary": "护士长审核后微调周六白班人员，提交审批",
+        "inserted_at": "2026-03-22T16:00:00Z"
       }
     ],
     "solver_runs": [
       {
-        "engine_type": "",
-        "status": "",
-        "score": "",
-        "hard_violation_count": "",
-        "started_at": "",
-        "completed_at": ""
+        "engine_type": "greedy",
+        "status": "completed",
+        "score": "850",
+        "hard_violation_count": "0",
+        "started_at": "2026-03-22T09:55:00Z",
+        "completed_at": "2026-03-22T09:55:12Z"
       },
       {
-        "engine_type": "",
-        "status": "",
-        "score": "",
-        "hard_violation_count": "",
-        "started_at": "",
-        "completed_at": ""
+        "engine_type": "or_tools",
+        "status": "completed",
+        "score": "920",
+        "hard_violation_count": "0",
+        "started_at": "2026-03-22T09:56:00Z",
+        "completed_at": "2026-03-22T09:57:30Z"
       },
       {
-        "engine_type": "",
-        "status": "",
-        "score": "",
-        "hard_violation_count": "",
-        "started_at": "",
-        "completed_at": ""
+        "engine_type": "or_tools",
+        "status": "failed",
+        "score": "0",
+        "hard_violation_count": "3",
+        "started_at": "2026-03-22T10:10:00Z",
+        "completed_at": "2026-03-22T10:10:05Z"
       }
+    ],
+    "coverage_summary": {
+      "total_slots": 42,
+      "filled_slots": 42,
+      "coverage_rate": "100%",
+      "shifts": [
+        {"name": "白班", "code": "day", "time": "08:00-16:00", "color": "#4CAF50", "daily_headcount": 2},
+        {"name": "小夜班", "code": "evening", "time": "16:00-00:00", "color": "#FF9800", "daily_headcount": 2},
+        {"name": "大夜班", "code": "night", "time": "00:00-08:00", "color": "#9C27B0", "daily_headcount": 2}
+      ]
+    },
+    "staff_list": [
+      {"employee_code": "N001", "name": "张三", "can_lead_shift": true, "work_restrictions": null},
+      {"employee_code": "N002", "name": "李四", "can_lead_shift": true, "work_restrictions": null},
+      {"employee_code": "N003", "name": "王五", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N004", "name": "赵六", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N005", "name": "陈七", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N006", "name": "周八", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N007", "name": "吴九", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N008", "name": "郑十", "can_lead_shift": false, "work_restrictions": null},
+      {"employee_code": "N009", "name": "刘十一", "can_lead_shift": false, "work_restrictions": "pregnant"},
+      {"employee_code": "N010", "name": "孙十二", "can_lead_shift": false, "work_restrictions": null}
+    ],
+    "constraints": [
+      {"name": "夜班后必须休息 12 小时", "category": "rest_after_night", "constraint_type": "hard", "enabled": true},
+      {"name": "连续工作不超过 6 天", "category": "max_consecutive_days", "constraint_type": "hard", "enabled": true},
+      {"name": "每班至少 1 名带班护士", "category": "lead_coverage", "constraint_type": "hard", "enabled": true},
+      {"name": "夜班公平分配", "category": "fair_night_distribution", "constraint_type": "soft", "weight": 80, "enabled": true},
+      {"name": "尊重班次偏好", "category": "respect_preference", "constraint_type": "soft", "weight": 40, "enabled": true}
     ]
   }
 }

--- a/travel/priv/repo/seeds.exs
+++ b/travel/priv/repo/seeds.exs
@@ -1,11 +1,64 @@
-# Script for populating the database. You can run it as:
+# Travel 域种子数据
 #
-#     mix run priv/repo/seeds.exs
+# 运行方式：mix run priv/repo/seeds.exs
 #
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     UniboExPoc.Repo.insert!(%UniboExPoc.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+# 创建最小验证数据集：
+# - 3 个航司（国航CA、东航MU、南航CZ）
+# - 3 个舱位等级（经济舱、公务舱、头等舱）
+# - 3 个酒店（北京国贸、上海华尔道夫、广州白天鹅）
+
+alias UniboExPoc.Travel.{TravelAirline, TravelCabinClass, TravelHotel}
+require Logger
+
+Logger.info("✈️  开始创建 Travel 种子数据...")
+
+# ── 1. 航司 ──────────────────────────────────────────────
+
+airline_data = [
+  %{airline_code: "AIR_CA", airline_name: "中国国际航空", iata_code: "CA", icao_code: "CCA", status: :active},
+  %{airline_code: "AIR_MU", airline_name: "中国东方航空", iata_code: "MU", icao_code: "CES", status: :active},
+  %{airline_code: "AIR_CZ", airline_name: "中国南方航空", iata_code: "CZ", icao_code: "CSN", status: :active}
+]
+
+airlines = Enum.map(airline_data, fn attrs ->
+  {:ok, airline} = Ash.create(TravelAirline, attrs, authorize?: false)
+  Logger.info("  航司: #{airline.airline_name} (#{airline.iata_code}/#{airline.icao_code})")
+  airline
+end)
+
+# ── 2. 舱位等级 ──────────────────────────────────────────
+
+cabin_class_data = [
+  %{cabin_class_code: "CC_F", cabin_class_name: "头等舱", cabin_rank: 1, status: :active},
+  %{cabin_class_code: "CC_C", cabin_class_name: "公务舱", cabin_rank: 2, status: :active},
+  %{cabin_class_code: "CC_Y", cabin_class_name: "经济舱", cabin_rank: 3, status: :active}
+]
+
+cabin_classes = Enum.map(cabin_class_data, fn attrs ->
+  {:ok, cc} = Ash.create(TravelCabinClass, attrs, authorize?: false)
+  Logger.info("  舱位: #{cc.cabin_class_name} (#{cc.cabin_class_code}, rank=#{cc.cabin_rank})")
+  cc
+end)
+
+# ── 3. 酒店 ──────────────────────────────────────────────
+
+hotel_data = [
+  %{hotel_code: "HTL_BJ_001", hotel_name: "北京国贸大酒店", city_code: "BJS", hotel_star: "五星级", status: :active},
+  %{hotel_code: "HTL_SH_002", hotel_name: "上海外滩华尔道夫酒店", city_code: "SHA", hotel_star: "五星级", status: :active},
+  %{hotel_code: "HTL_GZ_003", hotel_name: "广州白天鹅宾馆", city_code: "CAN", hotel_star: "五星级", status: :active}
+]
+
+hotels = Enum.map(hotel_data, fn attrs ->
+  {:ok, hotel} = Ash.create(TravelHotel, attrs, authorize?: false)
+  Logger.info("  酒店: #{hotel.hotel_name} (#{hotel.hotel_code}, #{hotel.city_code})")
+  hotel
+end)
+
+Logger.info("""
+
+✅ Travel 种子数据创建完成！
+
+  航司: #{length(airlines)} 个（国航CA、东航MU、南航CZ）
+  舱位: #{length(cabin_classes)} 个（头等舱、公务舱、经济舱）
+  酒店: #{length(hotels)} 个（北京、上海、广州）
+""")


### PR DESCRIPTION
## Summary
- **travel seed**: 将空壳 `travel/priv/repo/seeds.exs` 填充为真实种子数据（3 航司 CA/MU/CZ、3 舱位等级、3 酒店），数据从 travel mock JSON 提取
- **scheduling mock**: 将空壳 `scheduling_period_detail.expanded.mock.json` 填充为 ICU 2026年3月第4周排班详情（含 3 版本、3 求解器运行、10 名护士、5 条约束），数据从 scheduling seed 提取

## Test plan
- [ ] `wc -l travel/priv/repo/seeds.exs` 确认非空（64 行）
- [ ] `python3 -c "import json; json.load(open('hospital_scheduling/priv/static/scheduling_pages/scheduling/scheduling_period_detail.expanded.mock.json'))"` 确认 JSON 合法且非空壳

🤖 Generated with [Claude Code](https://claude.com/claude-code)