### PR TITLE
feat: Scheduling 域 8 个 user 页面

### DIFF
--- a/hospital_scheduling/pages/scheduling/user/leave_request.dsl
+++ b/hospital_scheduling/pages/scheduling/user/leave_request.dsl
@@ -1,0 +1,4 @@
+[PAGE: leave_request]
+  EXTENDS: base_form
+  META: Entity("ShiftAssignment"), Domain("Scheduling")
+  ATTR: Title("请假申请")

--- a/hospital_scheduling/pages/scheduling/user/my_schedule.dsl
+++ b/hospital_scheduling/pages/scheduling/user/my_schedule.dsl
@@ -1,0 +1,4 @@
+[PAGE: my_schedule]
+  EXTENDS: base_calendar_schedule
+  META: Entity("ShiftAssignment"), Domain("Scheduling")
+  ATTR: Title("我的排班")

--- a/hospital_scheduling/pages/scheduling/user/schedule_notification.dsl
+++ b/hospital_scheduling/pages/scheduling/user/schedule_notification.dsl
@@ -1,0 +1,4 @@
+[PAGE: schedule_notification]
+  EXTENDS: base_list_report
+  META: Entity("SchedulingPeriod"), Domain("Scheduling")
+  ATTR: Title("排班通知")

--- a/hospital_scheduling/pages/scheduling/user/schedule_overview.dsl
+++ b/hospital_scheduling/pages/scheduling/user/schedule_overview.dsl
@@ -1,0 +1,4 @@
+[PAGE: schedule_overview]
+  EXTENDS: base_overview
+  META: Entity("SchedulingPeriod"), Domain("Scheduling")
+  ATTR: Title("排班概览")

--- a/hospital_scheduling/pages/scheduling/user/shift_preference_form.dsl
+++ b/hospital_scheduling/pages/scheduling/user/shift_preference_form.dsl
@@ -1,0 +1,4 @@
+[PAGE: shift_preference_form]
+  EXTENDS: base_form
+  META: Entity("ShiftPreference"), Domain("Scheduling")
+  ATTR: Title("偏好设置")

--- a/hospital_scheduling/pages/scheduling/user/shift_swap_list.dsl
+++ b/hospital_scheduling/pages/scheduling/user/shift_swap_list.dsl
@@ -1,0 +1,4 @@
+[PAGE: shift_swap_list]
+  EXTENDS: base_list_report
+  META: Entity("ShiftPreference"), Domain("Scheduling")
+  ATTR: Title("换班请求列表")

--- a/hospital_scheduling/pages/scheduling/user/shift_swap_request.dsl
+++ b/hospital_scheduling/pages/scheduling/user/shift_swap_request.dsl
@@ -1,0 +1,4 @@
+[PAGE: shift_swap_request]
+  EXTENDS: base_form
+  META: Entity("ShiftPreference"), Domain("Scheduling")
+  ATTR: Title("换班申请")

--- a/hospital_scheduling/pages/scheduling/user/team_schedule.dsl
+++ b/hospital_scheduling/pages/scheduling/user/team_schedule.dsl
@@ -1,0 +1,4 @@
+[PAGE: team_schedule]
+  EXTENDS: base_calendar_schedule
+  META: Entity("ShiftAssignment"), Domain("Scheduling")
+  ATTR: Title("团队排班")


### PR DESCRIPTION
## Summary
- 新增 8 个 Scheduling user 页面 DSL：我的排班/团队排班/排班概览/换班申请/换班列表/偏好设置/请假申请/排班通知
- 全部使用 EXTENDS + META 模式继承 base 模板
- compile-frontend --seed scheduling 编译验证通过（18 DSL -> 136 文件）

## Test plan
- [x] 8 个 DSL 文件创建
- [x] compile-frontend --seed scheduling 通过
- [x] 编译产物生成 .heex + .meta.json

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)