### PR TITLE
fix: 搜索页统一使用 base_search_results 模板 (#191)

### DIFF
--- a/travel/pages/user/hotel_search_results.dsl
+++ b/travel/pages/user/hotel_search_results.dsl
@@ -1,9 +1,5 @@
-# 酒店搜索结果页
-# 按条件搜索酒店列表，支持筛选排序
-# 结构与机票/火车票差异较大（无日期横滑、无底部排序栏、有图片卡片），不使用 EXTENDS
-
-EXTENDS: base_list_report
-META: Entity("HotelOffer"), Domain("Travel"), Display("card_grid")
+EXTENDS: base_search_results
+META: Entity("HotelOffer"), Domain("Travel")
 
 [PAGE: hotel_search_results]
   ATTR: Title("酒店搜索")

--- a/travel/pages/user/train_search_results.dsl
+++ b/travel/pages/user/train_search_results.dsl
@@ -1,10 +1,8 @@
-# 火车票搜索结果页
-# 按条件搜索车次列表，支持日期横滑、筛选、排序
+EXTENDS: base_search_results
+META: Entity("TrainOffer"), Domain("Travel")
 
 [PAGE: train_search_results]
   ATTR: Title("火车票搜索")
-  META: Entity("TrainOffer"), Domain("Travel")
-  EXTENDS: base_search_results
 
   # 覆写顶部导航
   OVERRIDE: header_section


### PR DESCRIPTION
## Summary
- hotel_search_results: base_list_report → base_search_results
- train_search_results: META 移到顶层，统一格式

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)