### PR TITLE
fix: adapt_status 所有 record key 设实际数据，避免空默认值覆盖

### DIFF
--- a/travel/lib/unibo_ex_poc_web/graphql/stitch_backend.ex
+++ b/travel/lib/unibo_ex_poc_web/graphql/stitch_backend.ex
@@ -496,6 +496,19 @@ defmodule UniboExPocWeb.Graphql.StitchBackend do
         record = extract_record(value)
         record_var = detect_record_variable(defaults)
 
+        # 把实际数据设到所有 record-like key（值为 map 的 defaults key），
+        # 避免 detect_record_variable 非确定性导致空默认值覆盖实际数据 (#2155)
+        skip_keys = MapSet.new(["editing", "loading", "filter", "form", "rows", "rows_empty"])
+
+        state =
+          Enum.reduce(defaults, state, fn
+            {key, default_val}, acc when is_map(default_val) and is_binary(key) ->
+              if MapSet.member?(skip_keys, key), do: acc, else: Map.put(acc, key, record)
+
+            _, acc ->
+              acc
+          end)
+
         state
         |> Map.put(record_var, record)
         |> Map.put("form", state["form"] || record)


### PR DESCRIPTION
## Summary

- `adapt_status` 中 `detect_record_variable` 用 Map 遍历选 key 是非确定性的，当 defaults 同时有 `"record"` 和实体特定 key（如 `"train_offer"`）时，可能选中 `"record"` 而让 `"train_offer"` 保留空默认值，`deep_merge` 时空字符串覆盖实际数据
- 修复：在设置 `record_var` 之前，先遍历 defaults 中所有 record-like key（值为 map 且不在 skip_keys 中的），统一设为实际数据

Closes #2155

## Test plan

- [ ] 验证有多个 record-like key（如 `"record"` + `"train_offer"`）的页面，实际数据不被空默认值覆盖
- [ ] 验证只有单个 record key 的页面行为不变
- [ ] `mix compile` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)