### PR TITLE
fix: TravelCabinClass 补 activate/deactivate action 定义

### DIFF
--- a/travel/models/travel/travel.ubo.yaml
+++ b/travel/models/travel/travel.ubo.yaml
@@ -241,6 +241,12 @@ entities:
       type: update
       primary: true
       accept: [cabin_class_name, cabin_rank, status]
+    - name: activate
+      type: update
+      accept: []
+    - name: deactivate
+      type: update
+      accept: []
     changes:
     - effect: set_attribute
       field: id


### PR DESCRIPTION
## Summary
- TravelCabinClass 的 YAML 有 status enum（active/inactive）但 actions 中缺少 activate/deactivate，导致 GraphQL schema 中没有对应 mutation
- 参考 FlightOffer 的格式，补上 activate 和 deactivate 两个 update action（accept: []）

## Test plan
- [ ] 编译 travel 域，确认无报错
- [ ] 检查 GraphQL schema 中 TravelCabinClass 是否生成 activate/deactivate mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)